### PR TITLE
Rework signout in dio example

### DIFF
--- a/packages/fresh_dio/example/lib/authentication/bloc/authentication_bloc.dart
+++ b/packages/fresh_dio/example/lib/authentication/bloc/authentication_bloc.dart
@@ -30,7 +30,7 @@ class AuthenticationBloc
     if (event is AuthenticationStatusChanged) {
       yield _mapAuthenticationStatusChangedToState(event);
     } else if (event is LoggedOut) {
-      yield _mapLoggedOutToState();
+      _userRepository.signOut();
     }
   }
 
@@ -46,11 +46,6 @@ class AuthenticationBloc
       default:
         return AuthenticationUnknown();
     }
-  }
-
-  AuthenticationState _mapLoggedOutToState() {
-    _userRepository.signOut();
-    return AuthenticationUnauthenticated();
   }
 
   @override


### PR DESCRIPTION
- the call to `signOut` will end up setting token to null, which will end up pushing unauthenticated status
- feels more predictable to allow the incoming `Stream<UserAuthenticationStatus>` to fully dictate auth status for the user