### PR TITLE
Add generic <T> parameter to 'TokenHeaderBuilder'.

### DIFF
--- a/packages/fresh_dio/lib/src/fresh.dart
+++ b/packages/fresh_dio/lib/src/fresh.dart
@@ -28,7 +28,7 @@ class Fresh<T extends Token> extends Interceptor {
   Fresh({
     @required TokenStorage tokenStorage,
     @required RefreshToken<T> refreshToken,
-    TokenHeaderBuilder tokenHeader,
+    TokenHeaderBuilder<T> tokenHeader,
     ShouldRefresh shouldRefresh,
     Dio httpClient,
   })  : assert(tokenStorage != null),


### PR DESCRIPTION
The typedef TokenHeaderBuilder (in the fresh package) accepts a generic T parameter to specify the Token type of the 'Fresh' instance. Currently in the dio_fresh this parameter is not being used, Example:

```
Fresh<OAuth2Token>(
      tokenHeader: (token) {
//Here we currently lose the type information and checks. 
        return {'Authorization': (token as OAuth2Token).accessToken};
      },
...
    );

```