### PR TITLE
fix(fresh_dio): onResponse response is null case

### DIFF
--- a/packages/fresh_dio/lib/src/fresh.dart
+++ b/packages/fresh_dio/lib/src/fresh.dart
@@ -145,7 +145,7 @@ class Fresh<T extends Token> extends Interceptor {
   }
 
   static bool _defaultShouldRefresh(Response response) {
-    return response.statusCode == 401;
+    return response != null && response.statusCode == 401;
   }
 
   Future<T> _getToken() async {

--- a/packages/fresh_dio/lib/src/fresh.dart
+++ b/packages/fresh_dio/lib/src/fresh.dart
@@ -145,7 +145,7 @@ class Fresh<T extends Token> extends Interceptor {
   }
 
   static bool _defaultShouldRefresh(Response response) {
-    return response != null && response.statusCode == 401;
+    return response?.statusCode == 401;
   }
 
   Future<T> _getToken() async {

--- a/packages/fresh_dio/test/fresh_test.dart
+++ b/packages/fresh_dio/test/fresh_test.dart
@@ -298,6 +298,24 @@ void main() {
         expect(actual, response);
         verify(tokenStorage.delete()).called(1);
       });
+
+      test('returns null when token exists and response is null', () async {
+        tokenStorage = MockTokenStorage<MockToken>();
+        when(tokenStorage.read()).thenAnswer((_) async => MockToken());
+        when(tokenStorage.write(any)).thenAnswer((_) async => null);
+        final fresh = Fresh(
+          tokenStorage: tokenStorage,
+          refreshToken: emptyRefreshToken,
+        );
+        await expectLater(
+          fresh.authenticationStatus,
+          emitsInOrder([
+            AuthenticationStatus.authenticated,
+          ]),
+        );
+        final actual = await fresh.onResponse(null);
+        expect(actual, null);
+      });
     });
 
     group('onError', () {


### PR DESCRIPTION
This fixes #23 

Please let me know if there are any comments.

I also noticed running `pub run test_coverage` generates a `coverage_badge.svg` in the `packages/*` folder. This is not included in `.gitignore` right now, but I don't see it used anywhere now so I did not commit it. Maybe this could also be added to the root `.gitignore`? If you want I can also add another commit to update the `.gitignore`.

Thank you!