### PR TITLE
refactor(fresh_graphql): remove graphql package dependency

### DIFF
--- a/packages/fresh_graphql/lib/src/fresh_link.dart
+++ b/packages/fresh_graphql/lib/src/fresh_link.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 
 import 'package:fresh/fresh.dart';
-import 'package:graphql/client.dart';
+import 'package:gql_exec/gql_exec.dart';
+import 'package:gql_link/gql_link.dart';
 import 'package:http/http.dart' as http;
 
 /// Signature for `shouldRefresh` on [FreshLink].

--- a/packages/fresh_graphql/pubspec.yaml
+++ b/packages/fresh_graphql/pubspec.yaml
@@ -11,7 +11,8 @@ environment:
 
 dependencies:
   fresh: ^0.4.0
-  graphql: ^5.0.0
+  gql_exec: ^0.4.3
+  gql_link: ^0.5.1
   http: ^0.13.1
 
 dev_dependencies:

--- a/packages/fresh_graphql/test/fresh_test.dart
+++ b/packages/fresh_graphql/test/fresh_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: must_be_immutable
 
 import 'package:fresh_graphql/fresh_graphql.dart';
-import 'package:graphql/client.dart';
+import 'package:gql_exec/gql_exec.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
Since `fresh_graphql` depends on `graphql` package we get dependency issues while using with `ferry`. This PR will remove dependency with `graphql` and will depend on `gql_link` and `gql_exec` directly