### PR TITLE
fix(fresh): wait for initial storage read before returning token

### DIFF
--- a/packages/fresh/lib/src/fresh.dart
+++ b/packages/fresh/lib/src/fresh.dart
@@ -107,7 +107,9 @@ mixin FreshMixin<T> {
   /// Returns the current token.
   Future<T?> get token async {
     if (_authenticationStatus != AuthenticationStatus.initial) return _token;
-    await authenticationStatus.firstWhere((status) => status != AuthenticationStatus.initial);
+    await authenticationStatus.firstWhere(
+      (status) => status != AuthenticationStatus.initial,
+    );
     return _token;
   }
 

--- a/packages/fresh/lib/src/fresh.dart
+++ b/packages/fresh/lib/src/fresh.dart
@@ -107,7 +107,7 @@ mixin FreshMixin<T> {
   /// Returns the current token.
   Future<T?> get token async {
     if (_authenticationStatus != AuthenticationStatus.initial) return _token;
-    await authenticationStatus.first;
+    await authenticationStatus.firstWhere((status) => status != AuthenticationStatus.initial);
     return _token;
   }
 

--- a/packages/fresh/test/fresh_test.dart
+++ b/packages/fresh/test/fresh_test.dart
@@ -68,7 +68,7 @@ void main() {
         expect(token, mockToken);
       });
 
-      test('token waits for storage read to complete.', () async {
+      test('waits for storage read to complete', () async {
         final mockToken = MockToken();
         when(() => tokenStorage.read()).thenAnswer((_) async {
           await Future<void>.delayed(Duration.zero);

--- a/packages/fresh/test/fresh_test.dart
+++ b/packages/fresh/test/fresh_test.dart
@@ -67,6 +67,17 @@ void main() {
         final token = await freshController.token;
         expect(token, mockToken);
       });
+
+      test('token waits for storage read to complete.', () async {
+        final mockToken = MockToken();
+        when(() => tokenStorage.read()).thenAnswer((_) async {
+          await Future<void>.delayed(Duration.zero);
+          return mockToken;
+        });
+        final freshController = FreshController<OAuth2Token>(tokenStorage);
+        final token = await freshController.token;
+        expect(token, mockToken);
+      });
     });
 
     group('revokeToken', () {


### PR DESCRIPTION
This fix allows the initial token to be fetched asynchronously. See https://github.com/felangel/fresh/issues/70 for a snippet describing the issue