### PR TITLE
refactor(fresh_graphql): remove http dependency

### DIFF
--- a/packages/fresh_graphql/example/main.dart
+++ b/packages/fresh_graphql/example/main.dart
@@ -17,7 +17,7 @@ const getJobsQuery = '''
 void main() async {
   final freshLink = FreshLink.oAuth2(
     tokenStorage: InMemoryTokenStorage(),
-    refreshToken: (token, client) async {
+    refreshToken: (token) async {
       // Perform refresh and return new token
       print('refreshing token!');
       await Future<void>.delayed(const Duration(seconds: 1));

--- a/packages/fresh_graphql/lib/src/fresh_link.dart
+++ b/packages/fresh_graphql/lib/src/fresh_link.dart
@@ -3,13 +3,12 @@ import 'dart:async';
 import 'package:fresh/fresh.dart';
 import 'package:gql_exec/gql_exec.dart';
 import 'package:gql_link/gql_link.dart';
-import 'package:http/http.dart' as http;
 
 /// Signature for `shouldRefresh` on [FreshLink].
 typedef ShouldRefresh = bool Function(Response);
 
 /// Signature for `refreshToken` on [FreshLink].
-typedef RefreshToken<T> = Future<T> Function(T, http.Client);
+typedef RefreshToken<T> = Future<T> Function(T);
 
 /// {@template fresh_link}
 /// A GraphQL Link which handles manages an authentication token automatically.
@@ -103,10 +102,7 @@ class FreshLink<T> extends Link with FreshMixin<T> {
         final nextToken = await token;
         if (nextToken != null && _shouldRefresh(result)) {
           try {
-            final refreshedToken = await _refreshToken(
-              nextToken,
-              http.Client(),
-            );
+            final refreshedToken = await _refreshToken(nextToken);
             await setToken(refreshedToken);
             final tokenHeaders = _tokenHeader(refreshedToken);
             yield* forward(

--- a/packages/fresh_graphql/pubspec.yaml
+++ b/packages/fresh_graphql/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   fresh: ^0.4.0
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
-  http: ^1.0.0
 
 dev_dependencies:
   mocktail: ^0.3.0

--- a/packages/fresh_graphql/test/fresh_test.dart
+++ b/packages/fresh_graphql/test/fresh_test.dart
@@ -28,7 +28,7 @@ class MockRequest extends Mock implements Request {
 
 class MockResponse extends Mock implements Response {}
 
-Future<T?> emptyRefreshToken<T>(dynamic _, dynamic __) async => null;
+Future<T?> emptyRefreshToken<T>(dynamic _) async => null;
 
 void main() {
   setUpAll(() {
@@ -52,7 +52,7 @@ void main() {
         final request = MockRequest();
         final freshLink = FreshLink.oAuth2(
           tokenStorage: tokenStorage,
-          refreshToken: (_, __) async => null,
+          refreshToken: (_) async => null,
           shouldRefresh: (_) => false,
         );
         late MockRequest updatedRequest;
@@ -82,7 +82,7 @@ void main() {
         final request = MockRequest();
         final freshLink = FreshLink.oAuth2(
           tokenStorage: tokenStorage,
-          refreshToken: (_, __) async => null,
+          refreshToken: (_) async => null,
           shouldRefresh: (_) => false,
           tokenHeader: (token) =>
               {'custom_header': 'custom ${token?.accessToken}'},
@@ -106,7 +106,7 @@ void main() {
         final request = MockRequest();
         final freshLink = FreshLink.oAuth2(
           tokenStorage: tokenStorage,
-          refreshToken: (_, __) async => null,
+          refreshToken: (_) async => null,
           shouldRefresh: (_) => false,
         );
         await expectLater(
@@ -134,7 +134,7 @@ void main() {
         final freshLink = FreshLink<OAuth2Token>(
           shouldRefresh: (_) => false,
           tokenStorage: tokenStorage,
-          refreshToken: (_, __) async => null,
+          refreshToken: (_) async => null,
         );
         await expectLater(
           freshLink.request(request, (operation) async* {}),
@@ -151,7 +151,7 @@ void main() {
         final response = MockResponse();
         final freshLink = FreshLink.oAuth2(
           tokenStorage: tokenStorage,
-          refreshToken: (_, __) async {
+          refreshToken: (_) async {
             refreshTokenCallCount++;
             return const OAuth2Token(accessToken: 'token');
           },
@@ -177,7 +177,7 @@ void main() {
             .thenReturn([const GraphQLError(message: 'oops')]);
         final freshLink = FreshLink.oAuth2(
           tokenStorage: tokenStorage,
-          refreshToken: (_, __) async {
+          refreshToken: (_) async {
             refreshTokenCallCount++;
             return null;
           },
@@ -206,7 +206,7 @@ void main() {
             .thenReturn([const GraphQLError(message: 'oops')]);
         final freshLink = FreshLink.oAuth2(
           tokenStorage: tokenStorage,
-          refreshToken: (_, __) async {
+          refreshToken: (_) async {
             refreshTokenCallCount++;
             return refreshedToken;
           },
@@ -233,7 +233,7 @@ void main() {
         final response = MockResponse();
         final freshLink = FreshLink.oAuth2(
           tokenStorage: tokenStorage,
-          refreshToken: (_, __) async {
+          refreshToken: (_) async {
             refreshTokenCallCount++;
             throw RevokeTokenException();
           },


### PR DESCRIPTION
`fresh_graphql` has `http` as a dependency but it is not always used. We can safely remove `http` dependency and let user decide to choose either `dio` or `http`.