### PR TITLE
fix(fresh_graphql): should refresh before forwarding request

### DIFF
--- a/packages/fresh_graphql/lib/src/fresh_link.dart
+++ b/packages/fresh_graphql/lib/src/fresh_link.dart
@@ -6,7 +6,7 @@ import 'package:gql_link/gql_link.dart';
 import 'package:http/http.dart' as http;
 
 /// Signature for `shouldRefresh` on [FreshLink].
-typedef ShouldRefresh = bool Function(Response);
+typedef ShouldRefresh = bool Function(Request);
 
 /// Signature for `refreshToken` on [FreshLink].
 typedef RefreshToken<T> = Future<T> Function(T, http.Client);
@@ -85,11 +85,30 @@ class FreshLink<T> extends Link with FreshMixin<T> {
 
   @override
   Stream<Response> request(Request request, [NextLink? forward]) async* {
-    final currentToken = await token;
-    final tokenHeaders = currentToken != null
-        ? _tokenHeader(currentToken)
-        : const <String, String>{};
+    // fresh_graphql should not be used as the last link
+    if (forward == null) return;
 
+    final currentToken = await token;
+    if (currentToken == null) {
+      yield* forward(request);
+      return;
+    }
+
+    final T? activeToken;
+    if (_shouldRefresh(request)) {
+      try {
+        activeToken = await _refreshToken(currentToken, http.Client());
+        await setToken(activeToken);
+      } on RevokeTokenException catch (_) {
+        unawaited(revokeToken());
+        yield* forward(request);
+        return;
+      }
+    } else {
+      activeToken = currentToken;
+    }
+
+    final tokenHeaders = _tokenHeader(activeToken);
     final updatedRequest = request.updateContextEntry<HttpLinkHeaders>(
       (headers) => HttpLinkHeaders(
         headers: {
@@ -98,34 +117,6 @@ class FreshLink<T> extends Link with FreshMixin<T> {
       ),
     );
 
-    if (forward != null) {
-      await for (final result in forward(updatedRequest)) {
-        final nextToken = await token;
-        if (nextToken != null && _shouldRefresh(result)) {
-          try {
-            final refreshedToken = await _refreshToken(
-              nextToken,
-              http.Client(),
-            );
-            await setToken(refreshedToken);
-            final tokenHeaders = _tokenHeader(refreshedToken);
-            yield* forward(
-              request.updateContextEntry<HttpLinkHeaders>(
-                (headers) => HttpLinkHeaders(
-                  headers: {
-                    ...headers?.headers ?? <String, String>{},
-                  }..addAll(tokenHeaders),
-                ),
-              ),
-            );
-          } on RevokeTokenException catch (_) {
-            unawaited(revokeToken());
-            yield result;
-          }
-        } else {
-          yield result;
-        }
-      }
-    }
+    yield* forward(updatedRequest);
   }
 }

--- a/packages/fresh_graphql/pubspec.yaml
+++ b/packages/fresh_graphql/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/felangel/fresh/issues
 homepage: https://github.com/felangel/fresh
 funding: [https://github.com/sponsors/felangel]
 
-version: 0.6.1
+version: 0.7.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Thanks for the package @felangel!

Using `fresh_graphql` + `ferry` I noticed that the access token never refreshes if it had already expired. This seems to be happening due to `forward()` being called before the refresh logic happens (`_shouldRefresh()`). Ultimately this means that if the user steps away and the token expires, it never gets refreshed.

These changes seem to work fine with `ferry` but I'm happy to make changes as needed for other graphql clients.