### PR TITLE
fix(fresh_dio): clone `FormData` on retry

### DIFF
--- a/packages/fresh_dio/lib/src/fresh.dart
+++ b/packages/fresh_dio/lib/src/fresh.dart
@@ -162,10 +162,11 @@ Example:
 
     await setToken(refreshedToken);
     _httpClient.options.baseUrl = response.requestOptions.baseUrl;
+    final data = response.requestOptions.data;
     return _httpClient.request<dynamic>(
       response.requestOptions.path,
       cancelToken: response.requestOptions.cancelToken,
-      data: response.requestOptions.data,
+      data: data is FormData ? data.clone() : data,
       onReceiveProgress: response.requestOptions.onReceiveProgress,
       onSendProgress: response.requestOptions.onSendProgress,
       queryParameters: response.requestOptions.queryParameters,

--- a/packages/fresh_dio/test/fresh_test.dart
+++ b/packages/fresh_dio/test/fresh_test.dart
@@ -566,185 +566,185 @@ void main() {
         verify(() => tokenStorage.write(token)).called(1);
       });
 
-      group('RequestOptions.data handling', () {
-        test('clones FormData when retrying requests', () async {
-          var refreshCallCount = 0;
+      test(
+          'clones request data when retrying requests '
+          'when data is FormData', () async {
+        var refreshCallCount = 0;
 
-          final token = MockToken();
-          final tokenStorage = MockTokenStorage<MockToken>();
-          when(tokenStorage.read).thenAnswer((_) async => token);
-          when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+        final token = MockToken();
+        final tokenStorage = MockTokenStorage<MockToken>();
+        when(tokenStorage.read).thenAnswer((_) async => token);
+        when(() => tokenStorage.write(any())).thenAnswer((_) async {});
 
-          final formData = MockFormData();
-          final clonedFormData = MockFormData();
-          when(formData.clone).thenReturn(clonedFormData);
+        final formData = MockFormData();
+        final clonedFormData = MockFormData();
+        when(formData.clone).thenReturn(clonedFormData);
 
-          final request = MockRequestOptions();
-          when(() => request.path).thenReturn('/mock/path');
-          when(() => request.baseUrl).thenReturn('https://test.com');
-          when(() => request.headers).thenReturn(<String, String>{});
-          when(() => request.queryParameters).thenReturn(<String, String>{});
-          when(() => request.method).thenReturn('POST');
-          when(() => request.sendTimeout).thenReturn(Duration.zero);
-          when(() => request.receiveTimeout).thenReturn(Duration.zero);
-          when(() => request.extra).thenReturn(<String, String>{});
-          when(() => request.responseType).thenReturn(ResponseType.json);
-          when(() => request.validateStatus).thenReturn((_) => false);
-          when(() => request.receiveDataWhenStatusError).thenReturn(false);
-          when(() => request.followRedirects).thenReturn(false);
-          when(() => request.maxRedirects).thenReturn(0);
-          when(() => request.listFormat).thenReturn(ListFormat.multi);
-          when(() => request.contentType).thenReturn('multipart/form-data');
-          when(() => request.data).thenReturn(formData);
+        final request = MockRequestOptions();
+        when(() => request.path).thenReturn('/mock/path');
+        when(() => request.baseUrl).thenReturn('https://test.com');
+        when(() => request.headers).thenReturn(<String, String>{});
+        when(() => request.queryParameters).thenReturn(<String, String>{});
+        when(() => request.method).thenReturn('POST');
+        when(() => request.sendTimeout).thenReturn(Duration.zero);
+        when(() => request.receiveTimeout).thenReturn(Duration.zero);
+        when(() => request.extra).thenReturn(<String, String>{});
+        when(() => request.responseType).thenReturn(ResponseType.json);
+        when(() => request.validateStatus).thenReturn((_) => false);
+        when(() => request.receiveDataWhenStatusError).thenReturn(false);
+        when(() => request.followRedirects).thenReturn(false);
+        when(() => request.maxRedirects).thenReturn(0);
+        when(() => request.listFormat).thenReturn(ListFormat.multi);
+        when(() => request.contentType).thenReturn('multipart/form-data');
+        when(() => request.data).thenReturn(formData);
 
-          final error = MockDioException();
-          final response = MockResponse<dynamic>();
-          when(() => response.statusCode).thenReturn(401);
-          when(() => error.response).thenReturn(response);
-          when(() => response.requestOptions).thenReturn(request);
+        final error = MockDioException();
+        final response = MockResponse<dynamic>();
+        when(() => response.statusCode).thenReturn(401);
+        when(() => error.response).thenReturn(response);
+        when(() => response.requestOptions).thenReturn(request);
 
-          final options = MockOptions();
-          final httpClient = MockHttpClient();
-          when(() => httpClient.options).thenReturn(options);
-          when(
-            () => httpClient.request<dynamic>(
-              any(),
-              cancelToken: any(named: 'cancelToken'),
-              data: any<dynamic>(named: 'data'),
-              onReceiveProgress: any(named: 'onReceiveProgress'),
-              onSendProgress: any(named: 'onSendProgress'),
-              queryParameters: any(named: 'queryParameters'),
-              options: any(named: 'options'),
-            ),
-          ).thenAnswer((_) async => response);
+        final options = MockOptions();
+        final httpClient = MockHttpClient();
+        when(() => httpClient.options).thenReturn(options);
+        when(
+          () => httpClient.request<dynamic>(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            data: any<dynamic>(named: 'data'),
+            onReceiveProgress: any(named: 'onReceiveProgress'),
+            onSendProgress: any(named: 'onSendProgress'),
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          ),
+        ).thenAnswer((_) async => response);
 
-          final fresh = Fresh<MockToken>(
-            tokenStorage: tokenStorage,
-            refreshToken: (_, __) async {
-              refreshCallCount++;
-              return token;
-            },
-            tokenHeader: (_) => {
-              'custom-name': 'custom-value',
-            },
-            httpClient: httpClient,
-          );
+        final fresh = Fresh<MockToken>(
+          tokenStorage: tokenStorage,
+          refreshToken: (_, __) async {
+            refreshCallCount++;
+            return token;
+          },
+          tokenHeader: (_) => {
+            'custom-name': 'custom-value',
+          },
+          httpClient: httpClient,
+        );
 
-          await expectLater(
-            fresh.authenticationStatus,
-            emitsInOrder(
-              const <AuthenticationStatus>[
-                AuthenticationStatus.authenticated,
-              ],
-            ),
-          );
-          await fresh.onError(error, errorHandler);
+        await expectLater(
+          fresh.authenticationStatus,
+          emitsInOrder(
+            const <AuthenticationStatus>[
+              AuthenticationStatus.authenticated,
+            ],
+          ),
+        );
+        await fresh.onError(error, errorHandler);
 
-          final result = verify(() => errorHandler.resolve(captureAny()))
-            ..called(1);
-          final actual = result.captured.first as MockResponse;
-          expect(refreshCallCount, 1);
-          expect(actual, response);
-          verify(() => options.baseUrl = 'https://test.com').called(1);
-          verify(formData.clone).called(1);
-          verify(
-            () => httpClient.request<dynamic>(
-              '/mock/path',
-              queryParameters: <String, String>{},
-              data: clonedFormData,
-              options: any(named: 'options'),
-            ),
-          ).called(1);
-          verify(() => tokenStorage.write(token)).called(1);
-        });
+        final result = verify(() => errorHandler.resolve(captureAny()))
+          ..called(1);
+        final actual = result.captured.first as MockResponse;
+        expect(refreshCallCount, 1);
+        expect(actual, response);
+        verify(() => options.baseUrl = 'https://test.com').called(1);
+        verify(formData.clone).called(1);
+        verify(
+          () => httpClient.request<dynamic>(
+            '/mock/path',
+            queryParameters: <String, String>{},
+            data: clonedFormData,
+            options: any(named: 'options'),
+          ),
+        ).called(1);
+        verify(() => tokenStorage.write(token)).called(1);
+      });
 
-        test(
-            'avoids modifying RequestOptions.data during request retries '
-            'unless it is FormData', () async {
-          var refreshCallCount = 0;
+      test(
+          'does not modify request data during request retries '
+          'when data is not FormData', () async {
+        var refreshCallCount = 0;
 
-          final token = MockToken();
-          final tokenStorage = MockTokenStorage<MockToken>();
-          when(tokenStorage.read).thenAnswer((_) async => token);
-          when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+        final token = MockToken();
+        final tokenStorage = MockTokenStorage<MockToken>();
+        when(tokenStorage.read).thenAnswer((_) async => token);
+        when(() => tokenStorage.write(any())).thenAnswer((_) async {});
 
-          final data = Object();
-          final request = MockRequestOptions();
-          when(() => request.path).thenReturn('/mock/path');
-          when(() => request.baseUrl).thenReturn('https://test.com');
-          when(() => request.headers).thenReturn(<String, String>{});
-          when(() => request.queryParameters).thenReturn(<String, String>{});
-          when(() => request.method).thenReturn('POST');
-          when(() => request.sendTimeout).thenReturn(Duration.zero);
-          when(() => request.receiveTimeout).thenReturn(Duration.zero);
-          when(() => request.extra).thenReturn(<String, String>{});
-          when(() => request.responseType).thenReturn(ResponseType.json);
-          when(() => request.validateStatus).thenReturn((_) => false);
-          when(() => request.receiveDataWhenStatusError).thenReturn(false);
-          when(() => request.followRedirects).thenReturn(false);
-          when(() => request.maxRedirects).thenReturn(0);
-          when(() => request.listFormat).thenReturn(ListFormat.csv);
-          when(() => request.data).thenReturn(data);
+        final data = Object();
+        final request = MockRequestOptions();
+        when(() => request.path).thenReturn('/mock/path');
+        when(() => request.baseUrl).thenReturn('https://test.com');
+        when(() => request.headers).thenReturn(<String, String>{});
+        when(() => request.queryParameters).thenReturn(<String, String>{});
+        when(() => request.method).thenReturn('POST');
+        when(() => request.sendTimeout).thenReturn(Duration.zero);
+        when(() => request.receiveTimeout).thenReturn(Duration.zero);
+        when(() => request.extra).thenReturn(<String, String>{});
+        when(() => request.responseType).thenReturn(ResponseType.json);
+        when(() => request.validateStatus).thenReturn((_) => false);
+        when(() => request.receiveDataWhenStatusError).thenReturn(false);
+        when(() => request.followRedirects).thenReturn(false);
+        when(() => request.maxRedirects).thenReturn(0);
+        when(() => request.listFormat).thenReturn(ListFormat.csv);
+        when(() => request.data).thenReturn(data);
 
-          final error = MockDioException();
-          final response = MockResponse<dynamic>();
-          when(() => response.statusCode).thenReturn(401);
-          when(() => error.response).thenReturn(response);
-          when(() => response.requestOptions).thenReturn(request);
+        final error = MockDioException();
+        final response = MockResponse<dynamic>();
+        when(() => response.statusCode).thenReturn(401);
+        when(() => error.response).thenReturn(response);
+        when(() => response.requestOptions).thenReturn(request);
 
-          final options = MockOptions();
-          final httpClient = MockHttpClient();
-          when(() => httpClient.options).thenReturn(options);
-          when(
-            () => httpClient.request<dynamic>(
-              any(),
-              cancelToken: any(named: 'cancelToken'),
-              data: any<dynamic>(named: 'data'),
-              onReceiveProgress: any(named: 'onReceiveProgress'),
-              onSendProgress: any(named: 'onSendProgress'),
-              queryParameters: any(named: 'queryParameters'),
-              options: any(named: 'options'),
-            ),
-          ).thenAnswer((_) async => response);
+        final options = MockOptions();
+        final httpClient = MockHttpClient();
+        when(() => httpClient.options).thenReturn(options);
+        when(
+          () => httpClient.request<dynamic>(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            data: any<dynamic>(named: 'data'),
+            onReceiveProgress: any(named: 'onReceiveProgress'),
+            onSendProgress: any(named: 'onSendProgress'),
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          ),
+        ).thenAnswer((_) async => response);
 
-          final fresh = Fresh<MockToken>(
-            tokenStorage: tokenStorage,
-            refreshToken: (_, __) async {
-              refreshCallCount++;
-              return token;
-            },
-            tokenHeader: (_) => {
-              'custom-name': 'custom-value',
-            },
-            httpClient: httpClient,
-          );
+        final fresh = Fresh<MockToken>(
+          tokenStorage: tokenStorage,
+          refreshToken: (_, __) async {
+            refreshCallCount++;
+            return token;
+          },
+          tokenHeader: (_) => {
+            'custom-name': 'custom-value',
+          },
+          httpClient: httpClient,
+        );
 
-          await expectLater(
-            fresh.authenticationStatus,
-            emitsInOrder(
-              const <AuthenticationStatus>[
-                AuthenticationStatus.authenticated,
-              ],
-            ),
-          );
-          await fresh.onError(error, errorHandler);
+        await expectLater(
+          fresh.authenticationStatus,
+          emitsInOrder(
+            const <AuthenticationStatus>[
+              AuthenticationStatus.authenticated,
+            ],
+          ),
+        );
+        await fresh.onError(error, errorHandler);
 
-          final result = verify(() => errorHandler.resolve(captureAny()))
-            ..called(1);
-          final actual = result.captured.first as MockResponse;
-          expect(refreshCallCount, 1);
-          expect(actual, response);
-          verify(() => options.baseUrl = 'https://test.com').called(1);
-          verify(
-            () => httpClient.request<dynamic>(
-              '/mock/path',
-              queryParameters: <String, String>{},
-              data: data,
-              options: any(named: 'options'),
-            ),
-          ).called(1);
-          verify(() => tokenStorage.write(token)).called(1);
-        });
+        final result = verify(() => errorHandler.resolve(captureAny()))
+          ..called(1);
+        final actual = result.captured.first as MockResponse;
+        expect(refreshCallCount, 1);
+        expect(actual, response);
+        verify(() => options.baseUrl = 'https://test.com').called(1);
+        verify(
+          () => httpClient.request<dynamic>(
+            '/mock/path',
+            queryParameters: <String, String>{},
+            data: data,
+            options: any(named: 'options'),
+          ),
+        ).called(1);
+        verify(() => tokenStorage.write(token)).called(1);
       });
     });
 

--- a/packages/fresh_dio/test/fresh_test.dart
+++ b/packages/fresh_dio/test/fresh_test.dart
@@ -26,6 +26,8 @@ class MockErrorInterceptorHandler extends Mock
 
 class MockHttpClient extends Mock implements Dio {}
 
+class MockFormData extends Mock implements FormData {}
+
 class FakeRequestOptions extends Fake implements RequestOptions {}
 
 class FakeResponse<T> extends Fake implements Response<T> {}
@@ -562,6 +564,187 @@ void main() {
           ),
         ).called(1);
         verify(() => tokenStorage.write(token)).called(1);
+      });
+
+      group('RequestOptions.data handling', () {
+        test('clones FormData when retrying requests', () async {
+          var refreshCallCount = 0;
+
+          final token = MockToken();
+          final tokenStorage = MockTokenStorage<MockToken>();
+          when(tokenStorage.read).thenAnswer((_) async => token);
+          when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+
+          final formData = MockFormData();
+          final clonedFormData = MockFormData();
+          when(formData.clone).thenReturn(clonedFormData);
+
+          final request = MockRequestOptions();
+          when(() => request.path).thenReturn('/mock/path');
+          when(() => request.baseUrl).thenReturn('https://test.com');
+          when(() => request.headers).thenReturn(<String, String>{});
+          when(() => request.queryParameters).thenReturn(<String, String>{});
+          when(() => request.method).thenReturn('POST');
+          when(() => request.sendTimeout).thenReturn(Duration.zero);
+          when(() => request.receiveTimeout).thenReturn(Duration.zero);
+          when(() => request.extra).thenReturn(<String, String>{});
+          when(() => request.responseType).thenReturn(ResponseType.json);
+          when(() => request.validateStatus).thenReturn((_) => false);
+          when(() => request.receiveDataWhenStatusError).thenReturn(false);
+          when(() => request.followRedirects).thenReturn(false);
+          when(() => request.maxRedirects).thenReturn(0);
+          when(() => request.listFormat).thenReturn(ListFormat.multi);
+          when(() => request.contentType).thenReturn('multipart/form-data');
+          when(() => request.data).thenReturn(formData);
+
+          final error = MockDioException();
+          final response = MockResponse<dynamic>();
+          when(() => response.statusCode).thenReturn(401);
+          when(() => error.response).thenReturn(response);
+          when(() => response.requestOptions).thenReturn(request);
+
+          final options = MockOptions();
+          final httpClient = MockHttpClient();
+          when(() => httpClient.options).thenReturn(options);
+          when(
+            () => httpClient.request<dynamic>(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              data: any<dynamic>(named: 'data'),
+              onReceiveProgress: any(named: 'onReceiveProgress'),
+              onSendProgress: any(named: 'onSendProgress'),
+              queryParameters: any(named: 'queryParameters'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((_) async => response);
+
+          final fresh = Fresh<MockToken>(
+            tokenStorage: tokenStorage,
+            refreshToken: (_, __) async {
+              refreshCallCount++;
+              return token;
+            },
+            tokenHeader: (_) => {
+              'custom-name': 'custom-value',
+            },
+            httpClient: httpClient,
+          );
+
+          await expectLater(
+            fresh.authenticationStatus,
+            emitsInOrder(
+              const <AuthenticationStatus>[
+                AuthenticationStatus.authenticated,
+              ],
+            ),
+          );
+          await fresh.onError(error, errorHandler);
+
+          final result = verify(() => errorHandler.resolve(captureAny()))
+            ..called(1);
+          final actual = result.captured.first as MockResponse;
+          expect(refreshCallCount, 1);
+          expect(actual, response);
+          verify(() => options.baseUrl = 'https://test.com').called(1);
+          verify(formData.clone).called(1);
+          verify(
+            () => httpClient.request<dynamic>(
+              '/mock/path',
+              queryParameters: <String, String>{},
+              data: clonedFormData,
+              options: any(named: 'options'),
+            ),
+          ).called(1);
+          verify(() => tokenStorage.write(token)).called(1);
+        });
+
+        test(
+            'avoids modifying RequestOptions.data during request retries '
+            'unless it is FormData', () async {
+          var refreshCallCount = 0;
+
+          final token = MockToken();
+          final tokenStorage = MockTokenStorage<MockToken>();
+          when(tokenStorage.read).thenAnswer((_) async => token);
+          when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+
+          final data = Object();
+          final request = MockRequestOptions();
+          when(() => request.path).thenReturn('/mock/path');
+          when(() => request.baseUrl).thenReturn('https://test.com');
+          when(() => request.headers).thenReturn(<String, String>{});
+          when(() => request.queryParameters).thenReturn(<String, String>{});
+          when(() => request.method).thenReturn('POST');
+          when(() => request.sendTimeout).thenReturn(Duration.zero);
+          when(() => request.receiveTimeout).thenReturn(Duration.zero);
+          when(() => request.extra).thenReturn(<String, String>{});
+          when(() => request.responseType).thenReturn(ResponseType.json);
+          when(() => request.validateStatus).thenReturn((_) => false);
+          when(() => request.receiveDataWhenStatusError).thenReturn(false);
+          when(() => request.followRedirects).thenReturn(false);
+          when(() => request.maxRedirects).thenReturn(0);
+          when(() => request.listFormat).thenReturn(ListFormat.csv);
+          when(() => request.data).thenReturn(data);
+
+          final error = MockDioException();
+          final response = MockResponse<dynamic>();
+          when(() => response.statusCode).thenReturn(401);
+          when(() => error.response).thenReturn(response);
+          when(() => response.requestOptions).thenReturn(request);
+
+          final options = MockOptions();
+          final httpClient = MockHttpClient();
+          when(() => httpClient.options).thenReturn(options);
+          when(
+            () => httpClient.request<dynamic>(
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              data: any<dynamic>(named: 'data'),
+              onReceiveProgress: any(named: 'onReceiveProgress'),
+              onSendProgress: any(named: 'onSendProgress'),
+              queryParameters: any(named: 'queryParameters'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((_) async => response);
+
+          final fresh = Fresh<MockToken>(
+            tokenStorage: tokenStorage,
+            refreshToken: (_, __) async {
+              refreshCallCount++;
+              return token;
+            },
+            tokenHeader: (_) => {
+              'custom-name': 'custom-value',
+            },
+            httpClient: httpClient,
+          );
+
+          await expectLater(
+            fresh.authenticationStatus,
+            emitsInOrder(
+              const <AuthenticationStatus>[
+                AuthenticationStatus.authenticated,
+              ],
+            ),
+          );
+          await fresh.onError(error, errorHandler);
+
+          final result = verify(() => errorHandler.resolve(captureAny()))
+            ..called(1);
+          final actual = result.captured.first as MockResponse;
+          expect(refreshCallCount, 1);
+          expect(actual, response);
+          verify(() => options.baseUrl = 'https://test.com').called(1);
+          verify(
+            () => httpClient.request<dynamic>(
+              '/mock/path',
+              queryParameters: <String, String>{},
+              data: data,
+              options: any(named: 'options'),
+            ),
+          ).called(1);
+          verify(() => tokenStorage.write(token)).called(1);
+        });
       });
     });
 


### PR DESCRIPTION
## Problem

1. We make a **multipart/form-data** request.
2. The response returns an **authorization token error**.
3. **Fresh** 🍋 kicks in, successfully refreshes the token, and retries the request.
4. ❌ We get a **Dio error**:
_“The FormData has already been finalized. This typically means you are using the same FormData in repeated requests.”_

## Solution

Dio provides the `FormData.clone()` method, specifically designed to solve this issue. Dio documentation for the method states:
_“Convenience method to clone finalized FormData when retrying requests.”_

We just need to check the type of `RequestOptions.data` and call `clone()` if `RequestOptions.data is FormData`.

