### PR TITLE
feat: Enhanced token management with proactive validation and expiration support

### DIFF
--- a/packages/fresh/CHANGELOG.md
+++ b/packages/fresh/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.5.0
+
+- **BREAKING**: `OAuth2Token` is now final and cannot be extended
+  - Extend `AuthToken` instead of `OAuth2Token` for custom token types
+- feat: add `issuedAt` field to `AuthToken` base class
+- feat: `setToken` now automatically sets `issuedAt` if not provided
+- feat: add `AuthToken.expireDate` getter for token expiration validation
+- fix: address race condition in `setToken`/`clearToken` operations
+  - Token getter now waits for storage operations to complete
+  - Authentication status is set to `undetermined` during token updates
+
 # 0.4.3
 
 - fix: wait for initial storage read before returning token

--- a/packages/fresh/example/main.dart
+++ b/packages/fresh/example/main.dart
@@ -1,7 +1,7 @@
 import 'package:fresh/fresh.dart';
 
-class InMemoryTokenStorage implements TokenStorage<OAuth2Token> {
-  OAuth2Token? _token;
+class InMemoryTokenStorage<T extends AuthToken> implements TokenStorage<T> {
+  T? _token;
 
   @override
   Future<void> delete() async {
@@ -9,12 +9,12 @@ class InMemoryTokenStorage implements TokenStorage<OAuth2Token> {
   }
 
   @override
-  Future<OAuth2Token?> read() async {
+  Future<T?> read() async {
     return _token;
   }
 
   @override
-  Future<void> write(OAuth2Token token) async {
+  Future<void> write(T token) async {
     _token = token;
   }
 }

--- a/packages/fresh/lib/fresh.dart
+++ b/packages/fresh/lib/fresh.dart
@@ -1,1 +1,2 @@
+export 'src/auth_token.dart';
 export 'src/fresh.dart';

--- a/packages/fresh/lib/src/auth_token.dart
+++ b/packages/fresh/lib/src/auth_token.dart
@@ -1,13 +1,17 @@
 /// {@template auth_token}
 /// Base class for all authentication tokens.
 /// {@endtemplate}
-class AuthToken {
+abstract class AuthToken {
   /// {macro auth_token}
   const AuthToken({
     required this.accessToken,
     this.refreshToken,
     this.tokenType = 'bearer',
+    this.issuedAt,
   });
+
+  /// The date the token will expire.
+  DateTime? get expireDate => null;
 
   /// The access token string as issued by the authorization server.
   final String accessToken;
@@ -17,21 +21,38 @@ class AuthToken {
 
   /// The type of token this is, typically just the string “bearer”.
   final String? tokenType;
+
+  /// The date the token was issued.
+  final DateTime? issuedAt;
+
+  /// Creates a copy of the token with the given properties updated.
+  AuthToken copyWith({
+    String? accessToken,
+    String? refreshToken,
+    String? tokenType,
+    DateTime? issuedAt,
+  });
 }
 
 /// {@template oauth2_token}
 /// Standard OAuth2Token as defined by
 /// https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
+/// with added support for the issue date.
 /// {@endtemplate}
-class OAuth2Token extends AuthToken {
+interface class OAuth2Token extends AuthToken {
   /// {macro oauth2_token}
   const OAuth2Token({
     required super.accessToken,
     super.refreshToken,
     super.tokenType,
+    super.issuedAt,
     this.expiresIn,
     this.scope,
   });
+
+  /// The date the token will expire.
+  @override
+  DateTime? get expireDate => issuedAt?.add(Duration(seconds: expiresIn ?? 0));
 
   /// If the access token expires, the server should reply
   /// with the duration of time the access token is granted for.
@@ -40,35 +61,23 @@ class OAuth2Token extends AuthToken {
 
   /// Application scope granted as defined in https://oauth.net/2/scope
   final String? scope;
-}
 
-/// {@template fresh_token}
-/// Extended version of [OAuth2Token] with support for validation.
-/// {@endtemplate}
-class FreshAuthToken extends AuthToken {
-  /// {macro fresh_token}
-  const FreshAuthToken({
-    required super.accessToken,
-    super.refreshToken,
-    super.tokenType,
-    this.expireTime,
-    this.issuedAt,
-    this.userId,
-    this.scope,
-  });
-
-  /// The date the token will expire.
-  DateTime? get expireDate => issuedAt?.add(expireTime ?? Duration.zero);
-
-  /// The duration of the token's validity.
-  final Duration? expireTime;
-
-  /// The date the token was issued.
-  final DateTime? issuedAt;
-
-  /// The user id, this is used to identify the user in the system.
-  final Object? userId;
-
-  /// Application scope granted as defined in https://oauth.net/2/scope
-  final String? scope;
+  /// Creates a copy of the token with the given properties updated.
+  @override
+  OAuth2Token copyWith({
+    String? accessToken,
+    String? refreshToken,
+    String? tokenType,
+    DateTime? issuedAt,
+    int? expiresIn,
+    String? scope,
+  }) =>
+      OAuth2Token(
+        accessToken: accessToken ?? this.accessToken,
+        refreshToken: refreshToken ?? this.refreshToken,
+        tokenType: tokenType ?? this.tokenType,
+        issuedAt: issuedAt ?? this.issuedAt,
+        expiresIn: expiresIn ?? this.expiresIn,
+        scope: scope ?? this.scope,
+      );
 }

--- a/packages/fresh/lib/src/auth_token.dart
+++ b/packages/fresh/lib/src/auth_token.dart
@@ -1,3 +1,5 @@
+import 'package:fresh/src/fresh.dart';
+
 /// {@template auth_token}
 /// Base class for all authentication tokens.
 /// {@endtemplate}
@@ -23,6 +25,7 @@ abstract class AuthToken {
   final String? tokenType;
 
   /// The date the token was issued.
+  /// If not provided, set to the current date in [FreshMixin.setToken].
   final DateTime? issuedAt;
 
   /// Creates a copy of the token with the given properties updated.
@@ -38,6 +41,8 @@ abstract class AuthToken {
 /// Standard OAuth2Token as defined by
 /// https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
 /// with added support for the issue date.
+///
+/// Interface class to ensure that copyWith is correctly implemented.
 /// {@endtemplate}
 interface class OAuth2Token extends AuthToken {
   /// {macro oauth2_token}

--- a/packages/fresh/lib/src/auth_token.dart
+++ b/packages/fresh/lib/src/auth_token.dart
@@ -1,0 +1,74 @@
+/// {@template auth_token}
+/// Base class for all authentication tokens.
+/// {@endtemplate}
+class AuthToken {
+  /// {macro auth_token}
+  const AuthToken({
+    required this.accessToken,
+    this.refreshToken,
+    this.tokenType = 'bearer',
+  });
+
+  /// The access token string as issued by the authorization server.
+  final String accessToken;
+
+  /// Token which applications can use to obtain another access token.
+  final String? refreshToken;
+
+  /// The type of token this is, typically just the string “bearer”.
+  final String? tokenType;
+}
+
+/// {@template oauth2_token}
+/// Standard OAuth2Token as defined by
+/// https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
+/// {@endtemplate}
+class OAuth2Token extends AuthToken {
+  /// {macro oauth2_token}
+  const OAuth2Token({
+    required super.accessToken,
+    super.refreshToken,
+    super.tokenType,
+    this.expiresIn,
+    this.scope,
+  });
+
+  /// If the access token expires, the server should reply
+  /// with the duration of time the access token is granted for.
+  /// In seconds.
+  final int? expiresIn;
+
+  /// Application scope granted as defined in https://oauth.net/2/scope
+  final String? scope;
+}
+
+/// {@template fresh_token}
+/// Extended version of [OAuth2Token] with support for validation.
+/// {@endtemplate}
+class FreshAuthToken extends AuthToken {
+  /// {macro fresh_token}
+  const FreshAuthToken({
+    required super.accessToken,
+    super.refreshToken,
+    super.tokenType,
+    this.expireTime,
+    this.issuedAt,
+    this.userId,
+    this.scope,
+  });
+
+  /// The date the token will expire.
+  DateTime? get expireDate => issuedAt?.add(expireTime ?? Duration.zero);
+
+  /// The duration of the token's validity.
+  final Duration? expireTime;
+
+  /// The date the token was issued.
+  final DateTime? issuedAt;
+
+  /// The user id, this is used to identify the user in the system.
+  final Object? userId;
+
+  /// Application scope granted as defined in https://oauth.net/2/scope
+  final String? scope;
+}

--- a/packages/fresh/lib/src/fresh.dart
+++ b/packages/fresh/lib/src/fresh.dart
@@ -4,37 +4,6 @@ import 'dart:async';
 /// refresh fails and should result in a force-logout.
 class RevokeTokenException implements Exception {}
 
-/// {@template oauth2_token}
-/// Standard OAuth2Token as defined by
-/// https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
-/// {@endtemplate}
-class OAuth2Token {
-  /// {macro oauth2_token}
-  const OAuth2Token({
-    required this.accessToken,
-    this.tokenType = 'bearer',
-    this.expiresIn,
-    this.refreshToken,
-    this.scope,
-  });
-
-  /// The access token string as issued by the authorization server.
-  final String accessToken;
-
-  /// The type of token this is, typically just the string “bearer”.
-  final String? tokenType;
-
-  /// If the access token expires, the server should reply
-  /// with the duration of time the access token is granted for.
-  final int? expiresIn;
-
-  /// Token which applications can use to obtain another access token.
-  final String? refreshToken;
-
-  /// Application scope granted as defined in https://oauth.net/2/scope
-  final String? scope;
-}
-
 /// Enum representing the current authentication status of the application.
 enum AuthenticationStatus {
   /// The status before the true [AuthenticationStatus] has been determined.

--- a/packages/fresh/pubspec.yaml
+++ b/packages/fresh/pubspec.yaml
@@ -8,7 +8,7 @@ funding: [https://github.com/sponsors/felangel]
 version: 0.4.3
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dev_dependencies:
   mocktail: ^1.0.0

--- a/packages/fresh/pubspec.yaml
+++ b/packages/fresh/pubspec.yaml
@@ -8,7 +8,7 @@ funding: [https://github.com/sponsors/felangel]
 version: 0.4.3
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   mocktail: ^1.0.0

--- a/packages/fresh/pubspec.yaml
+++ b/packages/fresh/pubspec.yaml
@@ -5,10 +5,13 @@ issue_tracker: https://github.com/felangel/fresh/issues
 homepage: https://github.com/felangel/fresh
 funding: [https://github.com/sponsors/felangel]
 
-version: 0.4.3
+version: 0.5.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
+
+dependency:
+  meta: ^1.10.0
 
 dev_dependencies:
   mocktail: ^1.0.0

--- a/packages/fresh/test/fresh_test.dart
+++ b/packages/fresh/test/fresh_test.dart
@@ -136,15 +136,23 @@ void main() {
           when(() => tokenStorage.read()).thenAnswer((_) async => MockToken());
           when(() => tokenStorage.write(any())).thenAnswer((_) async {});
           final token = MockToken();
+          when(
+            () => token.copyWith(
+              issuedAt: any(named: 'issuedAt'),
+            ),
+          ).thenAnswer((_) => token);
+
           final freshController = FreshController<OAuth2Token>(tokenStorage);
           await freshController.setToken(token);
           verify(() => tokenStorage.write(token)).called(1);
         });
 
         test('adds unauthenticated status when call setToken(null)', () async {
-          when(() => tokenStorage.read()).thenAnswer((_) async => MockToken());
+          final token = MockToken();
+          when(() => tokenStorage.read()).thenAnswer((_) async => token);
           when(() => tokenStorage.write(any())).thenAnswer((_) async {});
           when(() => tokenStorage.delete()).thenAnswer((_) async {});
+
           final freshController = FreshController<OAuth2Token>(tokenStorage);
           await freshController.setToken(null);
           await expectLater(
@@ -159,7 +167,14 @@ void main() {
           when(() => tokenStorage.write(any())).thenAnswer((_) async {});
           final freshController = FreshController<OAuth2Token>(tokenStorage);
 
-          await freshController.setToken(MockToken());
+          final token = MockToken();
+          when(
+            () => token.copyWith(
+              issuedAt: any(named: 'issuedAt'),
+            ),
+          ).thenAnswer((_) => token);
+
+          await freshController.setToken(token);
 
           await expectLater(
             freshController.authenticationStatus,
@@ -191,10 +206,16 @@ void main() {
       test('shoud close streams', () async {
         when(() => tokenStorage.read()).thenAnswer((_) async => null);
         when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+        final token = MockToken();
+        when(
+          () => token.copyWith(
+            issuedAt: any(named: 'issuedAt'),
+          ),
+        ).thenAnswer((_) => token);
+
         final freshController = FreshController<OAuth2Token>(tokenStorage);
 
-        final mockToken = MockToken();
-        await freshController.setToken(mockToken);
+        await freshController.setToken(token);
         await freshController.close();
 
         await expectLater(

--- a/packages/fresh_dio/CHANGELOG.md
+++ b/packages/fresh_dio/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.5.0
+
+- feat: `ShouldRefreshBeforeRequest` allows conditional token refresh based on request details (path, headers, etc.) and token expiration
+- feat: automatic token refresh based on expiration before requests
+- feat: enhanced token validation with `AuthToken.expireDate`
+- chore: adjust dart sdk constraint to `">=3.0.0 <4.0.0"`
+
 # 0.4.3
 
 - fix: clone `FormData` on retry

--- a/packages/fresh_dio/lib/fresh_dio.dart
+++ b/packages/fresh_dio/lib/fresh_dio.dart
@@ -3,7 +3,6 @@ export 'package:fresh/fresh.dart'
     show
         AuthToken,
         AuthenticationStatus,
-        FreshAuthToken,
         FreshMixin,
         InMemoryTokenStorage,
         OAuth2Token,

--- a/packages/fresh_dio/lib/fresh_dio.dart
+++ b/packages/fresh_dio/lib/fresh_dio.dart
@@ -1,7 +1,9 @@
 export 'package:dio/dio.dart' show Dio, Response;
 export 'package:fresh/fresh.dart'
     show
+        AuthToken,
         AuthenticationStatus,
+        FreshAuthToken,
         FreshMixin,
         InMemoryTokenStorage,
         OAuth2Token,

--- a/packages/fresh_dio/lib/src/fresh.dart
+++ b/packages/fresh_dio/lib/src/fresh.dart
@@ -6,6 +6,9 @@ import 'package:fresh_dio/fresh_dio.dart';
 /// Signature for `shouldRefresh` on [Fresh].
 typedef ShouldRefresh = bool Function(Response<dynamic>? response);
 
+/// Signature for `shouldRefreshBeforeRequest` on [Fresh].
+typedef ShouldRefreshBeforeRequest<T> = bool Function(T? token);
+
 /// Signature for `refreshToken` on [Fresh].
 typedef RefreshToken<T> = Future<T> Function(T? token, Dio httpClient);
 
@@ -30,10 +33,13 @@ class Fresh<T> extends QueuedInterceptor with FreshMixin<T> {
     required TokenStorage<T> tokenStorage,
     required RefreshToken<T> refreshToken,
     ShouldRefresh? shouldRefresh,
+    ShouldRefreshBeforeRequest<T>? shouldRefreshBeforeRequest,
     Dio? httpClient,
   })  : _refreshToken = refreshToken,
         _tokenHeader = tokenHeader,
         _shouldRefresh = shouldRefresh ?? _defaultShouldRefresh,
+        _shouldRefreshBeforeRequest =
+            shouldRefreshBeforeRequest ?? _defaultShouldRefreshBeforeRequest,
         _httpClient = httpClient ?? Dio() {
     this.tokenStorage = tokenStorage;
   }
@@ -73,6 +79,7 @@ class Fresh<T> extends QueuedInterceptor with FreshMixin<T> {
   final Dio _httpClient;
   final TokenHeaderBuilder<T> _tokenHeader;
   final ShouldRefresh _shouldRefresh;
+  final ShouldRefreshBeforeRequest<T> _shouldRefreshBeforeRequest;
   final RefreshToken<T> _refreshToken;
 
   @override
@@ -103,7 +110,20 @@ Example:
 ''',
     );
 
-    final currentToken = await token;
+    var currentToken = await token;
+
+    final shouldRefresh = _shouldRefreshBeforeRequest(currentToken);
+    if (shouldRefresh) {
+      try {
+        final refreshedToken = await _refreshToken(currentToken, _httpClient);
+        await setToken(refreshedToken);
+      } on RevokeTokenException catch (_) {
+        await revokeToken();
+      }
+
+      currentToken = await token;
+    }
+
     final headers = currentToken != null
         ? _tokenHeader(currentToken)
         : const <String, String>{};
@@ -193,5 +213,18 @@ Example:
 
   static bool _defaultShouldRefresh(Response<dynamic>? response) {
     return response?.statusCode == 401;
+  }
+
+  static bool _defaultShouldRefreshBeforeRequest<T>(T? token) {
+    if (token is AuthToken) {
+      final now = DateTime.now();
+      final expireDate = token.expireDate;
+      if (expireDate == null) {
+        return false;
+      }
+      return expireDate.isBefore(now);
+    }
+
+    return false;
   }
 }

--- a/packages/fresh_dio/lib/src/fresh.dart
+++ b/packages/fresh_dio/lib/src/fresh.dart
@@ -7,7 +7,10 @@ import 'package:fresh_dio/fresh_dio.dart';
 typedef ShouldRefresh = bool Function(Response<dynamic>? response);
 
 /// Signature for `shouldRefreshBeforeRequest` on [Fresh].
-typedef ShouldRefreshBeforeRequest<T> = bool Function(T? token);
+typedef ShouldRefreshBeforeRequest<T> = bool Function(
+  RequestOptions requestOptions,
+  T? token,
+);
 
 /// Signature for `refreshToken` on [Fresh].
 typedef RefreshToken<T> = Future<T> Function(T? token, Dio httpClient);
@@ -112,7 +115,11 @@ Example:
 
     var currentToken = await token;
 
-    final shouldRefresh = _shouldRefreshBeforeRequest(currentToken);
+    final shouldRefresh = _shouldRefreshBeforeRequest(
+      options,
+      currentToken,
+    );
+
     if (shouldRefresh) {
       try {
         final refreshedToken = await _refreshToken(currentToken, _httpClient);
@@ -215,13 +222,12 @@ Example:
     return response?.statusCode == 401;
   }
 
-  static bool _defaultShouldRefreshBeforeRequest<T>(T? token) {
-    if (token is AuthToken) {
+  static bool _defaultShouldRefreshBeforeRequest<T>(
+    RequestOptions requestOptions,
+    T? token,
+  ) {
+    if (token case AuthToken(expireDate: final DateTime expireDate)) {
       final now = DateTime.now();
-      final expireDate = token.expireDate;
-      if (expireDate == null) {
-        return false;
-      }
       return expireDate.isBefore(now);
     }
 

--- a/packages/fresh_dio/lib/src/fresh.dart
+++ b/packages/fresh_dio/lib/src/fresh.dart
@@ -16,7 +16,7 @@ typedef RefreshToken<T> = Future<T> Function(T? token, Dio httpClient);
 ///
 /// ```dart
 /// dio.interceptors.add(
-///   Fresh<OAuth2Token>(
+///   Fresh<AuthToken>(
 ///     tokenStorage: InMemoryTokenStorage(),
 ///     refreshToken: (token, client) async {...},
 ///   ),
@@ -39,17 +39,17 @@ class Fresh<T> extends QueuedInterceptor with FreshMixin<T> {
   }
 
   /// A constructor that returns a [Fresh] interceptor that uses an
-  /// [OAuth2Token] token.
+  /// [AuthToken] token.
   ///
   /// ```dart
   /// dio.interceptors.add(
   ///   Fresh.oAuth2(
-  ///     tokenStorage: InMemoryTokenStorage<OAuth2Token>(),
+  ///     tokenStorage: InMemoryTokenStorage<AuthToken>(),
   ///     refreshToken: (token, client) async {...},
   ///   ),
   /// );
   /// ```
-  static Fresh<T> oAuth2<T extends OAuth2Token>({
+  static Fresh<T> oAuth2<T extends AuthToken>({
     required TokenStorage<T> tokenStorage,
     required RefreshToken<T> refreshToken,
     ShouldRefresh? shouldRefresh,

--- a/packages/fresh_dio/pubspec.yaml
+++ b/packages/fresh_dio/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/felangel/fresh/issues
 homepage: https://github.com/felangel/fresh
 funding: [https://github.com/sponsors/felangel]
 
-version: 0.4.3
+version: 0.5.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/fresh_dio/pubspec.yaml
+++ b/packages/fresh_dio/pubspec.yaml
@@ -8,7 +8,7 @@ funding: [https://github.com/sponsors/felangel]
 version: 0.4.3
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   dio: ^5.5.0+1

--- a/packages/fresh_dio/pubspec.yaml
+++ b/packages/fresh_dio/pubspec.yaml
@@ -12,7 +12,10 @@ environment:
 
 dependencies:
   dio: ^5.5.0+1
-  fresh: ^0.4.0
+
+  # TODO: replace path with pub.dev version before publishing
+  fresh:
+    path: ../fresh
 
 dev_dependencies:
   mocktail: ^1.0.0

--- a/packages/fresh_dio/test/fresh_test.dart
+++ b/packages/fresh_dio/test/fresh_test.dart
@@ -5,7 +5,10 @@ import 'package:test/test.dart';
 
 class MockTokenStorage<T> extends Mock implements TokenStorage<T> {}
 
-class MockToken extends Mock implements OAuth2Token {}
+class MockToken extends Mock implements OAuth2Token {
+  @override
+  String get accessToken => 'accessToken';
+}
 
 class MockRequestOptions extends Mock implements RequestOptions {}
 
@@ -63,13 +66,21 @@ void main() {
     group('configure token', () {
       group('setToken', () {
         test('invokes tokenStorage.write', () async {
-          when(() => tokenStorage.read()).thenAnswer((_) async => MockToken());
-          when(() => tokenStorage.write(any())).thenAnswer((_) async {});
           final token = MockToken();
+
+          when(() => tokenStorage.read()).thenAnswer((_) async => token);
+          when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+          when(
+            () => token.copyWith(
+              issuedAt: any(named: 'issuedAt'),
+            ),
+          ).thenAnswer((_) => token);
+
           final fresh = Fresh.oAuth2(
             tokenStorage: tokenStorage,
             refreshToken: emptyRefreshToken,
           );
+
           await fresh.setToken(token);
           verify(() => tokenStorage.write(token)).called(1);
         });
@@ -249,10 +260,17 @@ void main() {
       test(
           'returns untouched response when '
           'shouldRefresh (custom) is false', () async {
-        when(() => tokenStorage.read()).thenAnswer((_) async => MockToken());
+        final token = MockToken();
+        when(() => tokenStorage.read()).thenAnswer((_) async => token);
         when(() => tokenStorage.write(any())).thenAnswer((_) async {});
         final response = MockResponse<dynamic>();
         when(() => response.statusCode).thenReturn(200);
+        when(
+          () => token.copyWith(
+            issuedAt: any(named: 'issuedAt'),
+          ),
+        ).thenAnswer((_) => token);
+
         final fresh = Fresh.oAuth2(
           tokenStorage: tokenStorage,
           refreshToken: emptyRefreshToken,
@@ -307,6 +325,12 @@ void main() {
             options: any(named: 'options'),
           ),
         ).thenAnswer((_) async => response);
+        when(
+          () => token.copyWith(
+            issuedAt: any(named: 'issuedAt'),
+          ),
+        ).thenAnswer((_) => token);
+
         final fresh = Fresh<MockToken>(
           tokenStorage: tokenStorage,
           refreshToken: (_, __) async {
@@ -458,11 +482,18 @@ void main() {
       });
 
       test('returns error when error is RevokeTokenException', () async {
-        when(() => tokenStorage.read()).thenAnswer((_) async => MockToken());
+        final token = MockToken();
+        when(() => tokenStorage.read()).thenAnswer((_) async => token);
         when(() => tokenStorage.write(any())).thenAnswer((_) async {});
         final revokeTokenException = RevokeTokenException();
         final error = MockDioException();
         when<dynamic>(() => error.error).thenReturn(revokeTokenException);
+        when(
+          () => token.copyWith(
+            issuedAt: any(named: 'issuedAt'),
+          ),
+        ).thenAnswer((_) => token);
+
         final fresh = Fresh.oAuth2(
           tokenStorage: tokenStorage,
           refreshToken: emptyRefreshToken,
@@ -530,6 +561,12 @@ void main() {
             options: any(named: 'options'),
           ),
         ).thenAnswer((_) async => response);
+        when(
+          () => token.copyWith(
+            issuedAt: any(named: 'issuedAt'),
+          ),
+        ).thenAnswer((_) => token);
+
         final fresh = Fresh<MockToken>(
           tokenStorage: tokenStorage,
           refreshToken: (_, __) async {
@@ -618,6 +655,11 @@ void main() {
             options: any(named: 'options'),
           ),
         ).thenAnswer((_) async => response);
+        when(
+          () => token.copyWith(
+            issuedAt: any(named: 'issuedAt'),
+          ),
+        ).thenAnswer((_) => token);
 
         final fresh = Fresh<MockToken>(
           tokenStorage: tokenStorage,
@@ -707,6 +749,11 @@ void main() {
             options: any(named: 'options'),
           ),
         ).thenAnswer((_) async => response);
+        when(
+          () => token.copyWith(
+            issuedAt: any(named: 'issuedAt'),
+          ),
+        ).thenAnswer((_) => token);
 
         final fresh = Fresh<MockToken>(
           tokenStorage: tokenStorage,
@@ -750,15 +797,21 @@ void main() {
 
     group('close', () {
       test('should close streams', () async {
+        final token = MockToken();
         when(() => tokenStorage.read()).thenAnswer((_) async => null);
         when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+        when(
+          () => token.copyWith(
+            issuedAt: any(named: 'issuedAt'),
+          ),
+        ).thenAnswer((_) => token);
+
         final fresh = Fresh.oAuth2(
           tokenStorage: tokenStorage,
           refreshToken: emptyRefreshToken,
         );
 
-        final mockToken = MockToken();
-        await fresh.setToken(mockToken);
+        await fresh.setToken(token);
         await fresh.close();
 
         await expectLater(

--- a/packages/fresh_graphql/CHANGELOG.md
+++ b/packages/fresh_graphql/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.7.0
+
+- feat: `ShouldRefreshBeforeRequest` allows conditional token refresh based on GraphQL request details and token expiration
+- feat: automatic token refresh based on expiration before requests
+- feat: enhanced token validation with `AuthToken.expireDate`
+- chore: adjust dart sdk constraint to `">=3.0.0 <4.0.0"`
+
 # 0.6.1
 
 - chore: update copyright year

--- a/packages/fresh_graphql/lib/src/fresh_link.dart
+++ b/packages/fresh_graphql/lib/src/fresh_link.dart
@@ -15,7 +15,7 @@ typedef RefreshToken<T> = Future<T> Function(T, http.Client);
 /// A GraphQL Link which handles manages an authentication token automatically.
 ///
 /// A constructor that returns a Fresh interceptor that uses the
-/// [OAuth2Token] token, the standard token class and define the`
+/// [AuthToken] token, the standard token class and define the`
 /// tokenHeader as 'authorization': '${token.tokenType} ${token.accessToken}'
 ///
 /// ```dart
@@ -49,7 +49,7 @@ class FreshLink<T> extends Link with FreshMixin<T> {
   ///
   /// ```dart
   /// final freshLink = FreshLink.oAuth2(
-  ///   tokenStorage: InMemoryTokenStorage<OAuth2Token>(),
+  ///   tokenStorage: InMemoryTokenStorage<AuthToken>(),
   ///   refreshToken: (token, client) {
   ///     // Perform refresh and return new token
   ///   },
@@ -60,13 +60,13 @@ class FreshLink<T> extends Link with FreshMixin<T> {
   /// );
   /// ```
   /// {@endtemplate}
-  static FreshLink<OAuth2Token> oAuth2({
-    required TokenStorage<OAuth2Token> tokenStorage,
-    required RefreshToken<OAuth2Token?> refreshToken,
+  static FreshLink<T> oAuth2<T extends AuthToken>({
+    required TokenStorage<T> tokenStorage,
+    required RefreshToken<T?> refreshToken,
     required ShouldRefresh shouldRefresh,
-    TokenHeaderBuilder<OAuth2Token?>? tokenHeader,
+    TokenHeaderBuilder<T?>? tokenHeader,
   }) {
-    return FreshLink<OAuth2Token>(
+    return FreshLink<T>(
       refreshToken: refreshToken,
       tokenStorage: tokenStorage,
       shouldRefresh: shouldRefresh,

--- a/packages/fresh_graphql/pubspec.yaml
+++ b/packages/fresh_graphql/pubspec.yaml
@@ -8,7 +8,7 @@ funding: [https://github.com/sponsors/felangel]
 version: 0.6.1
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   # TODO: replace path with pub.dev version before publishing

--- a/packages/fresh_graphql/pubspec.yaml
+++ b/packages/fresh_graphql/pubspec.yaml
@@ -11,7 +11,10 @@ environment:
   sdk: ">=2.15.0 <4.0.0"
 
 dependencies:
-  fresh: ^0.4.0
+  # TODO: replace path with pub.dev version before publishing
+  fresh:
+    path: ../fresh
+
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
   http: ^1.0.0

--- a/packages/fresh_graphql/pubspec.yaml
+++ b/packages/fresh_graphql/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/felangel/fresh/issues
 homepage: https://github.com/felangel/fresh
 funding: [https://github.com/sponsors/felangel]
 
-version: 0.6.1
+version: 0.7.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/fresh_graphql/test/fresh_test.dart
+++ b/packages/fresh_graphql/test/fresh_test.dart
@@ -256,6 +256,12 @@ void main() {
           when(() => tokenStorage.read()).thenAnswer((_) async => null);
           when(() => tokenStorage.write(any())).thenAnswer((_) async {});
           final token = MockOAuth2Token();
+          when(
+            () => token.copyWith(
+              issuedAt: any(named: 'issuedAt'),
+            ),
+          ).thenAnswer((_) => token);
+
           final freshLink = FreshLink.oAuth2<OAuth2Token>(
             tokenStorage: tokenStorage,
             refreshToken: emptyRefreshToken,
@@ -282,10 +288,16 @@ void main() {
 
       group('clearToken', () {
         test('invokes tokenStorage.delete', () async {
-          when(() => tokenStorage.read())
-              .thenAnswer((_) async => MockOAuth2Token());
+          final token = MockOAuth2Token();
+          when(() => tokenStorage.read()).thenAnswer((_) async => token);
           when(() => tokenStorage.write(any())).thenAnswer((_) async {});
           when(() => tokenStorage.delete()).thenAnswer((_) async {});
+          when(
+            () => token.copyWith(
+              issuedAt: any(named: 'issuedAt'),
+            ),
+          ).thenAnswer((_) => token);
+
           final freshLink = FreshLink.oAuth2<OAuth2Token>(
             tokenStorage: tokenStorage,
             refreshToken: emptyRefreshToken,
@@ -301,14 +313,20 @@ void main() {
       test('should close streams', () async {
         when(() => tokenStorage.read()).thenAnswer((_) async => null);
         when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+        final token = MockOAuth2Token();
+        when(
+          () => token.copyWith(
+            issuedAt: any(named: 'issuedAt'),
+          ),
+        ).thenAnswer((_) => token);
+
         final fresh = FreshLink.oAuth2<OAuth2Token>(
           tokenStorage: tokenStorage,
           refreshToken: emptyRefreshToken,
           shouldRefresh: (_) => false,
         );
 
-        final mockToken = MockToken();
-        await fresh.setToken(mockToken);
+        await fresh.setToken(token);
         await fresh.close();
 
         await expectLater(

--- a/packages/fresh_graphql/test/fresh_test.dart
+++ b/packages/fresh_graphql/test/fresh_test.dart
@@ -50,7 +50,7 @@ void main() {
           'request context headers', () async {
         when(() => tokenStorage.read()).thenAnswer((_) async => token);
         final request = MockRequest();
-        final freshLink = FreshLink.oAuth2(
+        final freshLink = FreshLink.oAuth2<OAuth2Token>(
           tokenStorage: tokenStorage,
           refreshToken: (_, __) async => null,
           shouldRefresh: (_) => false,
@@ -80,7 +80,7 @@ void main() {
           'operation context headers', () async {
         when(() => tokenStorage.read()).thenAnswer((_) async => token);
         final request = MockRequest();
-        final freshLink = FreshLink.oAuth2(
+        final freshLink = FreshLink.oAuth2<OAuth2Token>(
           tokenStorage: tokenStorage,
           refreshToken: (_, __) async => null,
           shouldRefresh: (_) => false,
@@ -104,7 +104,7 @@ void main() {
           'operation context headers when token is null', () async {
         when(() => tokenStorage.read()).thenAnswer((_) async => null);
         final request = MockRequest();
-        final freshLink = FreshLink.oAuth2(
+        final freshLink = FreshLink.oAuth2<OAuth2Token>(
           tokenStorage: tokenStorage,
           refreshToken: (_, __) async => null,
           shouldRefresh: (_) => false,
@@ -175,7 +175,7 @@ void main() {
         final response = MockResponse();
         when(() => response.errors)
             .thenReturn([const GraphQLError(message: 'oops')]);
-        final freshLink = FreshLink.oAuth2(
+        final freshLink = FreshLink.oAuth2<OAuth2Token>(
           tokenStorage: tokenStorage,
           refreshToken: (_, __) async {
             refreshTokenCallCount++;
@@ -256,7 +256,7 @@ void main() {
           when(() => tokenStorage.read()).thenAnswer((_) async => null);
           when(() => tokenStorage.write(any())).thenAnswer((_) async {});
           final token = MockOAuth2Token();
-          final freshLink = FreshLink.oAuth2(
+          final freshLink = FreshLink.oAuth2<OAuth2Token>(
             tokenStorage: tokenStorage,
             refreshToken: emptyRefreshToken,
             shouldRefresh: (_) => false,
@@ -270,7 +270,7 @@ void main() {
               .thenAnswer((_) async => MockOAuth2Token());
           when(() => tokenStorage.write(any())).thenAnswer((_) async {});
           when(() => tokenStorage.delete()).thenAnswer((_) async {});
-          final freshLink = FreshLink.oAuth2(
+          final freshLink = FreshLink.oAuth2<OAuth2Token>(
             tokenStorage: tokenStorage,
             refreshToken: emptyRefreshToken,
             shouldRefresh: (_) => false,
@@ -286,7 +286,7 @@ void main() {
               .thenAnswer((_) async => MockOAuth2Token());
           when(() => tokenStorage.write(any())).thenAnswer((_) async {});
           when(() => tokenStorage.delete()).thenAnswer((_) async {});
-          final freshLink = FreshLink.oAuth2(
+          final freshLink = FreshLink.oAuth2<OAuth2Token>(
             tokenStorage: tokenStorage,
             refreshToken: emptyRefreshToken,
             shouldRefresh: (_) => false,
@@ -301,7 +301,7 @@ void main() {
       test('should close streams', () async {
         when(() => tokenStorage.read()).thenAnswer((_) async => null);
         when(() => tokenStorage.write(any())).thenAnswer((_) async {});
-        final fresh = FreshLink.oAuth2(
+        final fresh = FreshLink.oAuth2<OAuth2Token>(
           tokenStorage: tokenStorage,
           refreshToken: emptyRefreshToken,
           shouldRefresh: (_) => false,


### PR DESCRIPTION
### Overview
Comprehensive token management improvements that enable proactive token validation before requests, automatic expiration handling https://github.com/felangel/fresh/issues/110

### Key Features
- **Proactive token validation** with `ShouldRefreshBeforeRequest` callback supporting request context (RequestOptions/Request + Token)
- **Automatic token expiration** handling via `AuthToken.expireDate` with built-in validation
- **Enhanced token metadata** with automatic `issuedAt` timestamping
- **Race condition fixes** in `setToken`/`clearToken` operations
- **Comprehensive test coverage** with 16+ new tests

### Breaking Changes
- **`OAuth2Token` is now interface** - extend `AuthToken` instead for custom tokens
  - **Alternative approaches considered:**
    1. `@mustBeOverridden` for copyWith (Can be ignored, possibly resetting parameters when copyWith)
    2. Create default `issuedAt` when creating a class (not const class, otherwise a good option)
    3. External metadata storage outside the token model (breaks encapsulation, requires storage update) 
 
 **Approach:** Clean inheritance hierarchy via `AuthToken` and `OAuth2Token` with automatic metadata management 
  
  @felangel wdyt?

### Architecture Benefits
- **Clean separation of concerns** with abstract `AuthToken` base class
- **Type-safe token validation** with proper generics
- **Request-aware refresh logic** for fine-grained control
- **Backward compatible** default implementations

### Related work
- [PR #111](https://github.com/felangel/fresh/pull/111)
- [PR #112](https://github.com/felangel/fresh/pull/112)

### Packages bump
- `fresh`: 0.4.3 → 0.5.0
- `fresh_dio`: 0.4.3 → 0.5.0  
- `fresh_graphql`: 0.6.1 → 0.7.0