### PR TITLE
fix: Await pending refresh before sending new requests

### DIFF
--- a/packages/fresh/CHANGELOG.md
+++ b/packages/fresh/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.2
+
+- feat: add `tokenWaitingRefresh` getter to `FreshMixin` — awaits any in-flight refresh before returning the current token ([#141](https://github.com/felangel/fresh/issues/141), [#142](https://github.com/felangel/fresh/pull/142))
+
 # 0.6.1.
 
 - fix: guard authenticationStatus emits on whether internal controller is closed

--- a/packages/fresh/README.md
+++ b/packages/fresh/README.md
@@ -62,4 +62,4 @@ class MyHttpFresh extends MyHttpClient with FreshMixin<OAuth2Token> {
 }
 ```
 
-`refreshToken()` handles deduplication automatically - concurrent calls share a single in-flight refresh.
+`refreshToken()` handles deduplication automatically - concurrent calls share a single in-flight refresh. Use `tokenWaitingRefresh` instead of `token` before sending requests to wait for any in-flight refresh and avoid dispatching with a stale token.

--- a/packages/fresh/lib/src/fresh.dart
+++ b/packages/fresh/lib/src/fresh.dart
@@ -158,6 +158,23 @@ mixin FreshMixin<T> {
   /// Calling this method more than once is allowed, but does nothing.
   Future<void> close() => _controller.close();
 
+  /// Returns the current token, waiting for any in-flight refresh to
+  /// complete first. Unlike [refreshToken], this does **not** start a new
+  /// refresh — it only piggy-backs on one that is already running.
+  ///
+  /// Use this before sending a request to avoid using a stale token while
+  /// another request is already refreshing it.
+  @protected
+  Future<T?> get tokenWaitingRefresh async {
+    final pending = _refreshFuture;
+    if (pending != null) {
+      try {
+        await pending;
+      } catch (_) {}
+    }
+    return token;
+  }
+
   /// Performs the token refresh operation.
   ///
   /// Implementers should provide only the raw token refresh mechanism.

--- a/packages/fresh/test/fresh_test.dart
+++ b/packages/fresh/test/fresh_test.dart
@@ -23,6 +23,9 @@ class FreshController<T> with FreshMixin<T> {
 
   Future<T> Function(T? token)? refreshTokenFn;
 
+  // Expose @protected getter for testing.
+  Future<T?> get testTokenWaitingRefresh => tokenWaitingRefresh;
+
   @override
   Future<T> performTokenRefresh(T? token) {
     final refreshAction = refreshTokenFn;
@@ -522,6 +525,51 @@ void main() {
           expect(result, currentToken);
         },
       );
+    });
+
+    group('tokenWaitingRefresh', () {
+      setUpAll(() {
+        registerFallbackValue(FakeOAuth2Token());
+      });
+
+      test('returns current token when no refresh is pending', () async {
+        final token = MockToken();
+        when(() => tokenStorage.read()).thenAnswer((_) async => token);
+        when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+
+        final freshController = FreshController<OAuth2Token>(tokenStorage);
+        await freshController.setToken(token);
+
+        final result = await freshController.testTokenWaitingRefresh;
+        expect(result, token);
+      });
+
+      test('waits for in-flight refresh and returns updated token', () async {
+        final oldToken = MockToken();
+        final newToken = MockToken();
+        final refreshCompleter = Completer<OAuth2Token>();
+
+        when(() => tokenStorage.read()).thenAnswer((_) async => oldToken);
+        when(() => tokenStorage.write(any())).thenAnswer((_) async {});
+
+        final freshController = FreshController<OAuth2Token>(tokenStorage);
+        await freshController.setToken(oldToken);
+
+        freshController.refreshTokenFn = (_) => refreshCompleter.future;
+
+        // Start a refresh without awaiting to simulate an in-flight refresh.
+        // ignore: unused_local_variable
+        final pendingRefresh =
+            freshController.refreshToken(tokenUsedForRequest: oldToken);
+
+        // tokenWaitingRefresh should wait for the in-flight refresh
+        final resultFuture = freshController.testTokenWaitingRefresh;
+
+        refreshCompleter.complete(newToken);
+
+        final result = await resultFuture;
+        expect(result, newToken);
+      });
     });
 
     group('initial storage read', () {

--- a/packages/fresh_dio/CHANGELOG.md
+++ b/packages/fresh_dio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1
+
+- fix: new requests during in-flight token refresh no longer sent with stale token ([#141](https://github.com/felangel/fresh/issues/141), [#142](https://github.com/felangel/fresh/pull/142))
+
 # 0.6.0
 
 - **BREAKING** feat: adjust the default `shouldRefreshBeforeRequest` to automatically refresh if the token expires within 30s

--- a/packages/fresh_dio/README.md
+++ b/packages/fresh_dio/README.md
@@ -85,7 +85,7 @@ dio.interceptors.add(
 1. **Before each request**: If the token has an `expiresAt` date in the past, it is refreshed proactively.
 2. **Auth header**: The current token is attached to the request as an `Authorization` header.
 3. **On 401 response**: The token is refreshed and the request is retried automatically.
-4. **Concurrent requests**: If multiple requests trigger a refresh simultaneously, only one refresh call is made. The others wait for the result.
+4. **Concurrent requests**: If multiple requests trigger a refresh simultaneously, only one refresh call is made. The others wait for the result. New requests arriving while a refresh is in-flight also wait and are sent with the updated token.
 
 ## Authentication Status
 

--- a/packages/fresh_dio/lib/src/fresh.dart
+++ b/packages/fresh_dio/lib/src/fresh.dart
@@ -153,7 +153,11 @@ Example:
       return handler.next(options);
     }
 
-    var currentToken = await token;
+    // Wait for any in-flight refresh (triggered by a 401 in onError/onResponse)
+    // before reading the token. QueuedInterceptor runs onRequest and onError
+    // on separate queues, so without this a new request could be sent with a
+    // stale token that the backend has already invalidated.
+    var currentToken = await tokenWaitingRefresh;
 
     final shouldRefresh = _shouldRefreshBeforeRequest(
       options,

--- a/packages/fresh_dio/test/concurrent_refresh_test.dart
+++ b/packages/fresh_dio/test/concurrent_refresh_test.dart
@@ -354,6 +354,186 @@ void main() {
     );
 
     test(
+      'WITHOUT fix: new request during in-flight refresh gets '
+      'unnecessary 401 due to separate QueuedInterceptor queues',
+      () async {
+        var refreshCallCount = 0;
+        final refreshCompleter = Completer<OAuth2Token>();
+        var total401Count = 0;
+
+        final mockAdapter = _MockAdapter(
+          (options) {
+            final auth = options.headers['authorization'] as String?;
+            if (auth == 'bearer new.token.jwt') {
+              return ResponseBody.fromString(
+                '{"success": true}',
+                200,
+                headers: {
+                  Headers.contentTypeHeader: [Headers.jsonContentType],
+                },
+              );
+            }
+            total401Count++;
+            return ResponseBody.fromString(
+              '{"error": "Unauthorized"}',
+              401,
+              headers: {
+                Headers.contentTypeHeader: [Headers.jsonContentType],
+              },
+            );
+          },
+        );
+
+        final retryClient = Dio()..httpClientAdapter = mockAdapter;
+
+        // _UnfixedFresh overrides tokenWaitingRefresh to NOT wait,
+        // simulating the behavior without the fix.
+        final fresh = _UnfixedFresh(
+          tokenStorage: InMemoryTokenStorage<OAuth2Token>(),
+          refreshToken: (_, __) async {
+            refreshCallCount++;
+            return refreshCompleter.future;
+          },
+          tokenHeader: (token) => {
+            'authorization': '${token.tokenType} ${token.accessToken}',
+          },
+          httpClient: retryClient,
+        );
+
+        await fresh.setToken(
+          const OAuth2Token(
+            accessToken: 'old.token.jwt',
+            refreshToken: 'refreshToken',
+          ),
+        );
+
+        final dio = Dio()..httpClientAdapter = mockAdapter;
+        dio.interceptors.add(fresh);
+
+        final future1 = dio.get<Object?>('http://example.com/1');
+        await pumpEventQueue();
+        expect(refreshCallCount, equals(1));
+
+        // Without the fix, onRequest doesn't wait for the in-flight refresh
+        // and sends the request with the old (invalidated) token.
+        final future2 = dio.get<Object?>('http://example.com/2');
+        await pumpEventQueue();
+
+        refreshCompleter.complete(
+          const OAuth2Token(
+            accessToken: 'new.token.jwt',
+            refreshToken: 'newRefreshToken',
+          ),
+        );
+
+        final responses = await Future.wait([future1, future2]);
+
+        for (final response in responses) {
+          expect(response.statusCode, equals(200));
+        }
+
+        expect(refreshCallCount, equals(1));
+
+        // 2 backend 401s: request 1 (expected) + request 2 (unnecessary).
+        expect(
+          total401Count,
+          equals(2),
+          reason: 'Without fix, request 2 is sent with the old token '
+              'while refresh is in-flight, causing an extra 401',
+        );
+      },
+    );
+
+    test(
+      'WITH fix: new request during in-flight refresh waits for refresh '
+      'and avoids unnecessary 401',
+      () async {
+        var refreshCallCount = 0;
+        final refreshCompleter = Completer<OAuth2Token>();
+        var total401Count = 0;
+
+        final mockAdapter = _MockAdapter(
+          (options) {
+            final auth = options.headers['authorization'] as String?;
+            if (auth == 'bearer new.token.jwt') {
+              return ResponseBody.fromString(
+                '{"success": true}',
+                200,
+                headers: {
+                  Headers.contentTypeHeader: [Headers.jsonContentType],
+                },
+              );
+            }
+            total401Count++;
+            return ResponseBody.fromString(
+              '{"error": "Unauthorized"}',
+              401,
+              headers: {
+                Headers.contentTypeHeader: [Headers.jsonContentType],
+              },
+            );
+          },
+        );
+
+        final retryClient = Dio()..httpClientAdapter = mockAdapter;
+
+        final fresh = Fresh.oAuth2(
+          tokenStorage: InMemoryTokenStorage<OAuth2Token>(),
+          refreshToken: (_, __) async {
+            refreshCallCount++;
+            return refreshCompleter.future;
+          },
+          httpClient: retryClient,
+        );
+
+        await fresh.setToken(
+          const OAuth2Token(
+            accessToken: 'old.token.jwt',
+            refreshToken: 'refreshToken',
+          ),
+        );
+
+        final dio = Dio()..httpClientAdapter = mockAdapter;
+        dio.interceptors.add(fresh);
+
+        // First request → 401 → triggers refresh
+        final future1 = dio.get<Object?>('http://example.com/1');
+        await pumpEventQueue();
+        expect(refreshCallCount, equals(1));
+
+        // New request while refresh is in-flight.
+        // tokenWaitingRefresh in onRequest causes it to wait for the
+        // in-flight refresh, so it will use the new token immediately.
+        final future2 = dio.get<Object?>('http://example.com/2');
+        await pumpEventQueue();
+
+        refreshCompleter.complete(
+          const OAuth2Token(
+            accessToken: 'new.token.jwt',
+            refreshToken: 'newRefreshToken',
+          ),
+        );
+
+        final responses = await Future.wait([future1, future2]);
+
+        for (final response in responses) {
+          expect(response.statusCode, equals(200));
+        }
+
+        expect(refreshCallCount, equals(1));
+
+        // Request 2 waited for the refresh and was sent with the new token,
+        // so only 1 backend 401 (from request 1).
+        expect(
+          total401Count,
+          equals(1),
+          reason: 'Request 2 should wait for refresh and use new token '
+              'instead of getting an unnecessary 401',
+        );
+      },
+    );
+
+    test(
       'after successful refresh, a later 401 triggers a new refresh',
       () async {
         var refreshCallCount = 0;
@@ -450,6 +630,26 @@ class _MockAdapter implements HttpClientAdapter {
   ) async {
     return onFetch(options);
   }
+}
+
+/// Simulates Fresh WITHOUT the tokenWaitingRefresh fix.
+/// [tokenWaitingRefresh] falls back to [token], so onRequest never waits
+/// for an in-flight refresh triggered by onError.
+class _UnfixedFresh extends Fresh<OAuth2Token> {
+  _UnfixedFresh({
+    required TokenStorage<OAuth2Token> tokenStorage,
+    required RefreshToken<OAuth2Token> refreshToken,
+    required TokenHeaderBuilder<OAuth2Token> tokenHeader,
+    Dio? httpClient,
+  }) : super(
+          tokenStorage: tokenStorage,
+          refreshToken: refreshToken,
+          tokenHeader: tokenHeader,
+          httpClient: httpClient,
+        );
+
+  @override
+  Future<OAuth2Token?> get tokenWaitingRefresh => token;
 }
 
 class _TrackingTokenStorage<T> implements TokenStorage<T> {

--- a/packages/fresh_graphql/CHANGELOG.md
+++ b/packages/fresh_graphql/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.1
+
+- fix: new requests during in-flight token refresh no longer sent with stale token ([#141](https://github.com/felangel/fresh/issues/141), [#142](https://github.com/felangel/fresh/pull/142))
+
 # 0.8.0
 
 - **BREAKING** feat: adjust the default `shouldRefreshBeforeRequest` to automatically refresh if the token expires within 30s

--- a/packages/fresh_graphql/README.md
+++ b/packages/fresh_graphql/README.md
@@ -89,7 +89,7 @@ final freshLink = FreshLink<String>(
 1. **Before each request**: If the token has an `expiresAt` date in the past, it is refreshed proactively.
 2. **Auth header**: The current token is attached to the request via `HttpLinkHeaders`.
 3. **On error response**: When `shouldRefresh` returns true, the token is refreshed and the request is retried.
-4. **Concurrent requests**: If multiple GraphQL streams trigger a refresh simultaneously, only one refresh call is made. The others wait for the result.
+4. **Concurrent requests**: If multiple GraphQL streams trigger a refresh simultaneously, only one refresh call is made. The others wait for the result. New requests arriving while a refresh is in-flight also wait and are sent with the updated token.
 
 ## Authentication Status
 

--- a/packages/fresh_graphql/lib/src/fresh_link.dart
+++ b/packages/fresh_graphql/lib/src/fresh_link.dart
@@ -111,7 +111,10 @@ class FreshLink<T> extends Link with FreshMixin<T> {
 
   @override
   Stream<Response> request(Request request, [NextLink? forward]) async* {
-    var currentToken = await token;
+    // Wait for any in-flight refresh before reading the token. Without this,
+    // concurrent request() calls could use a stale token that the backend has
+    // already invalidated during a refresh triggered by another request.
+    var currentToken = await tokenWaitingRefresh;
 
     final shouldRefresh = _shouldRefreshBeforeRequest.call(
       request,

--- a/packages/fresh_graphql/test/concurrent_refresh_test.dart
+++ b/packages/fresh_graphql/test/concurrent_refresh_test.dart
@@ -372,6 +372,160 @@ void main() {
     );
 
     test(
+      'WITHOUT fix: new request during in-flight refresh '
+      'gets unnecessary UNAUTHENTICATED error',
+      () async {
+        var refreshCallCount = 0;
+        final refreshCompleter = Completer<OAuth2Token>();
+        var totalAuthErrorCount = 0;
+
+        final freshLink = _UnfixedFreshLink(
+          tokenStorage: _TrackingTokenStorage<OAuth2Token>(),
+          refreshToken: (_, __) async {
+            refreshCallCount++;
+            return refreshCompleter.future;
+          },
+          shouldRefresh: (response) =>
+              response.errors?.any(
+                (e) => e.message.contains('UNAUTHENTICATED'),
+              ) ??
+              false,
+          tokenHeader: (token) => {
+            'authorization': '${token?.tokenType} ${token?.accessToken}',
+          },
+        );
+
+        await freshLink.setToken(
+          const OAuth2Token(
+            accessToken: 'old.token.jwt',
+            refreshToken: 'refreshToken',
+          ),
+        );
+
+        Stream<Response> mockForward(Request request) async* {
+          final authHeader = request.context
+              .entry<HttpLinkHeaders>()
+              ?.headers['authorization'];
+
+          if (authHeader == 'bearer new.token.jwt') {
+            yield MockResponse(data: {'result': 'success'});
+          } else {
+            totalAuthErrorCount++;
+            yield MockResponse(
+              errors: [const GraphQLError(message: 'UNAUTHENTICATED')],
+            );
+          }
+        }
+
+        final future1 = freshLink.request(MockRequest(), mockForward).toList();
+        await pumpEventQueue();
+        expect(refreshCallCount, equals(1));
+
+        final future2 = freshLink.request(MockRequest(), mockForward).toList();
+        await pumpEventQueue();
+
+        refreshCompleter.complete(
+          const OAuth2Token(
+            accessToken: 'new.token.jwt',
+            refreshToken: 'newRefreshToken',
+          ),
+        );
+
+        final results = await Future.wait([future1, future2]).timeout(
+          const Duration(seconds: 5),
+          onTimeout: () => throw TimeoutException('Streams hung'),
+        );
+
+        for (final result in results) {
+          expect(result, isNotEmpty);
+        }
+
+        expect(refreshCallCount, equals(1));
+        expect(
+          totalAuthErrorCount,
+          equals(2),
+          reason: 'Without fix, request 2 is sent with the old token '
+              'while refresh is in-flight, causing an extra auth error',
+        );
+      },
+    );
+
+    test(
+      'WITH fix: new request during in-flight refresh waits '
+      'and avoids unnecessary UNAUTHENTICATED error',
+      () async {
+        var refreshCallCount = 0;
+        final refreshCompleter = Completer<OAuth2Token>();
+        var totalAuthErrorCount = 0;
+
+        final freshLink = FreshLink.oAuth2(
+          tokenStorage: _TrackingTokenStorage<OAuth2Token>(),
+          refreshToken: (_, __) async {
+            refreshCallCount++;
+            return refreshCompleter.future;
+          },
+          shouldRefresh: (response) =>
+              response.errors?.any(
+                (e) => e.message.contains('UNAUTHENTICATED'),
+              ) ??
+              false,
+        );
+
+        await freshLink.setToken(
+          const OAuth2Token(
+            accessToken: 'old.token.jwt',
+            refreshToken: 'refreshToken',
+          ),
+        );
+
+        Stream<Response> mockForward(Request request) async* {
+          final authHeader = request.context
+              .entry<HttpLinkHeaders>()
+              ?.headers['authorization'];
+
+          if (authHeader == 'bearer new.token.jwt') {
+            yield MockResponse(data: {'result': 'success'});
+          } else {
+            totalAuthErrorCount++;
+            yield MockResponse(
+              errors: [const GraphQLError(message: 'UNAUTHENTICATED')],
+            );
+          }
+        }
+
+        final future1 = freshLink.request(MockRequest(), mockForward).toList();
+        await pumpEventQueue();
+        expect(refreshCallCount, equals(1));
+
+        final future2 = freshLink.request(MockRequest(), mockForward).toList();
+        await pumpEventQueue();
+
+        refreshCompleter.complete(
+          const OAuth2Token(
+            accessToken: 'new.token.jwt',
+            refreshToken: 'newRefreshToken',
+          ),
+        );
+
+        final results = await Future.wait([future1, future2]).timeout(
+          const Duration(seconds: 5),
+          onTimeout: () => throw TimeoutException('Streams hung'),
+        );
+
+        for (final result in results) {
+          expect(result, isNotEmpty);
+        }
+
+        expect(refreshCallCount, equals(1));
+        expect(
+          totalAuthErrorCount,
+          equals(1),
+          reason: 'With fix, request 2 waits for refresh and uses new token',
+        );
+      },
+    );
+
+    test(
       'after successful refresh, a later auth error triggers a new refresh',
       () async {
         var refreshCallCount = 0;
@@ -439,6 +593,24 @@ void main() {
       },
     );
   });
+}
+
+/// Simulates FreshLink WITHOUT the tokenWaitingRefresh fix.
+class _UnfixedFreshLink extends FreshLink<OAuth2Token> {
+  _UnfixedFreshLink({
+    required TokenStorage<OAuth2Token> tokenStorage,
+    required RefreshToken<OAuth2Token?> refreshToken,
+    required ShouldRefresh shouldRefresh,
+    TokenHeaderBuilder<OAuth2Token?>? tokenHeader,
+  }) : super(
+          tokenStorage: tokenStorage,
+          refreshToken: refreshToken,
+          shouldRefresh: shouldRefresh,
+          tokenHeader: tokenHeader,
+        );
+
+  @override
+  Future<OAuth2Token?> get tokenWaitingRefresh => token;
 }
 
 class _TrackingTokenStorage<T> implements TokenStorage<T> {

--- a/packages/fresh_http/CHANGELOG.md
+++ b/packages/fresh_http/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1
+
+- fix: new requests during in-flight token refresh no longer sent with stale token ([#141](https://github.com/felangel/fresh/issues/141), [#142](https://github.com/felangel/fresh/pull/142))
+
 # 0.1.0
 
 - feat: initial implementation that has feature parity with `fresh_dio` and `fresh_graphql`

--- a/packages/fresh_http/README.md
+++ b/packages/fresh_http/README.md
@@ -97,7 +97,8 @@ final client = Fresh<String>(
    automatically.
 4. **Concurrent requests**: If multiple requests trigger a refresh
    simultaneously, only one refresh call is made. The others wait for the
-   result.
+   result. New requests arriving while a refresh is in-flight also wait and
+   are sent with the updated token.
 
 ## Authentication Status
 

--- a/packages/fresh_http/lib/src/fresh.dart
+++ b/packages/fresh_http/lib/src/fresh.dart
@@ -109,7 +109,10 @@ class Fresh<T> extends http.BaseClient with FreshMixin<T> {
       return _httpClient.send(request);
     }
 
-    var currentToken = await token;
+    // Wait for any in-flight refresh before reading the token. Without this,
+    // concurrent send() calls could use a stale token that the backend has
+    // already invalidated during a refresh triggered by another request.
+    var currentToken = await tokenWaitingRefresh;
     final shouldRefresh = _shouldRefreshBeforeRequest(request, currentToken);
 
     if (shouldRefresh) {

--- a/packages/fresh_http/test/concurrent_refresh_test.dart
+++ b/packages/fresh_http/test/concurrent_refresh_test.dart
@@ -316,6 +316,146 @@ void main() {
     });
 
     test(
+        'WITHOUT fix: new request during in-flight refresh '
+        'gets unnecessary 401', () async {
+      var refreshCallCount = 0;
+      final refreshCompleter = Completer<OAuth2Token>();
+      var total401Count = 0;
+
+      final mockClient = _mockClient((request) {
+        final auth = request.headers['authorization'];
+        if (auth == 'bearer new.token.jwt') {
+          return http.Response(
+            '{"success": true}',
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        total401Count++;
+        return http.Response(
+          '{"error": "Unauthorized"}',
+          401,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      // _UnfixedFresh overrides tokenWaitingRefresh to NOT wait,
+      // simulating behavior without the fix.
+      final fresh = _UnfixedFresh(
+        tokenStorage: InMemoryTokenStorage<OAuth2Token>(),
+        refreshToken: (_, __) async {
+          refreshCallCount++;
+          return refreshCompleter.future;
+        },
+        tokenHeader: (token) => {
+          'authorization': '${token.tokenType} ${token.accessToken}',
+        },
+        httpClient: mockClient,
+      );
+
+      await fresh.setToken(
+        const OAuth2Token(
+          accessToken: 'old.token.jwt',
+          refreshToken: 'refreshToken',
+        ),
+      );
+
+      final future1 = fresh.get(Uri.parse('http://example.com/1'));
+      await pumpEventQueue();
+      expect(refreshCallCount, equals(1));
+
+      final future2 = fresh.get(Uri.parse('http://example.com/2'));
+      await pumpEventQueue();
+
+      refreshCompleter.complete(
+        const OAuth2Token(
+          accessToken: 'new.token.jwt',
+          refreshToken: 'newRefreshToken',
+        ),
+      );
+
+      final responses = await Future.wait([future1, future2]);
+      for (final response in responses) {
+        expect(response.statusCode, equals(200));
+      }
+
+      expect(refreshCallCount, equals(1));
+      expect(
+        total401Count,
+        equals(2),
+        reason: 'Without fix, request 2 is sent with the old token '
+            'while refresh is in-flight, causing an extra 401',
+      );
+    });
+
+    test(
+        'WITH fix: new request during in-flight refresh waits '
+        'and avoids unnecessary 401', () async {
+      var refreshCallCount = 0;
+      final refreshCompleter = Completer<OAuth2Token>();
+      var total401Count = 0;
+
+      final mockClient = _mockClient((request) {
+        final auth = request.headers['authorization'];
+        if (auth == 'bearer new.token.jwt') {
+          return http.Response(
+            '{"success": true}',
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        total401Count++;
+        return http.Response(
+          '{"error": "Unauthorized"}',
+          401,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final fresh = Fresh.oAuth2(
+        tokenStorage: InMemoryTokenStorage<OAuth2Token>(),
+        refreshToken: (_, __) async {
+          refreshCallCount++;
+          return refreshCompleter.future;
+        },
+        httpClient: mockClient,
+      );
+
+      await fresh.setToken(
+        const OAuth2Token(
+          accessToken: 'old.token.jwt',
+          refreshToken: 'refreshToken',
+        ),
+      );
+
+      final future1 = fresh.get(Uri.parse('http://example.com/1'));
+      await pumpEventQueue();
+      expect(refreshCallCount, equals(1));
+
+      final future2 = fresh.get(Uri.parse('http://example.com/2'));
+      await pumpEventQueue();
+
+      refreshCompleter.complete(
+        const OAuth2Token(
+          accessToken: 'new.token.jwt',
+          refreshToken: 'newRefreshToken',
+        ),
+      );
+
+      final responses = await Future.wait([future1, future2]);
+      for (final response in responses) {
+        expect(response.statusCode, equals(200));
+      }
+
+      expect(refreshCallCount, equals(1));
+      expect(
+        total401Count,
+        equals(1),
+        reason: 'With fix, request 2 waits for refresh and uses new token',
+      );
+    });
+
+    test(
         'after successful refresh, '
         'a subsequent 401 triggers a new refresh', () async {
       var refreshCallCount = 0;
@@ -387,6 +527,24 @@ http.Client _mockClient(
   http.Response Function(http.Request request) handler,
 ) {
   return MockClient((request) async => handler(request));
+}
+
+/// Simulates Fresh WITHOUT the tokenWaitingRefresh fix.
+class _UnfixedFresh extends Fresh<OAuth2Token> {
+  _UnfixedFresh({
+    required TokenStorage<OAuth2Token> tokenStorage,
+    required RefreshToken<OAuth2Token> refreshToken,
+    required TokenHeaderBuilder<OAuth2Token> tokenHeader,
+    http.Client? httpClient,
+  }) : super(
+          tokenStorage: tokenStorage,
+          refreshToken: refreshToken,
+          tokenHeader: tokenHeader,
+          httpClient: httpClient,
+        );
+
+  @override
+  Future<OAuth2Token?> get tokenWaitingRefresh => token;
 }
 
 class _TrackingTokenStorage<T> implements TokenStorage<T> {


### PR DESCRIPTION
## Summary

Fixes #141 - New requests sent with stale token while refresh is in-flight.

- Add `tokenWaitingRefresh` getter to `FreshMixin` that awaits `_refreshFuture` without starting a new refresh
- Use it in `onRequest` (fresh_dio), `send()` (fresh_http), and `request()` (fresh_graphql) before reading the token
- Eliminates unnecessary 401/UNAUTHENTICATED responses for requests arriving during the refresh window

## Problem

`QueuedInterceptor` (Dio) runs `onRequest` and `onError` on **separate queues**. While `onError` is awaiting a token refresh, new requests pass through `onRequest` with the old (already invalidated) token, causing unnecessary 401 round-trips. The same applies to `fresh_http` and `fresh_graphql` where `send()`/`request()` are fully concurrent.

PR #130 correctly prevents multiple parallel `refreshToken` calls, but does not prevent new requests from being dispatched with a stale token during the refresh window.

## Solution

A single new getter in `FreshMixin`:

```dart
@protected
Future<T?> get tokenWaitingRefresh async {
  final pending = _refreshFuture;
  if (pending != null) {
    try {
      await pending;
    } catch (_) {}
  }
  return token;
}
```

It piggy-backs on the existing `_refreshFuture` from #130, no new dependencies, no changes to the refresh lifecycle.

This is kept as a **separate getter** from `token` intentionally: merging the waiting logic into `token` would risk deadlocks if `performTokenRefresh` implementations ever read `token`.

## Changes

| File | Change |
|------|--------|
| `fresh/lib/src/fresh.dart` | Add `tokenWaitingRefresh` to `FreshMixin` |
| `fresh_dio/lib/src/fresh.dart` | `onRequest`: `await token` → `await tokenWaitingRefresh` |
| `fresh_http/lib/src/fresh.dart` | `send()`: `await token` → `await tokenWaitingRefresh` |
| `fresh_graphql/lib/src/fresh_link.dart` | `request()`: `await token` → `await tokenWaitingRefresh` |

## Test Coverage

Added 2 tests per package (fresh_dio, fresh_http, fresh_graphql) - 6 total:

| Test | What it verifies |
|------|-----------------|
| **WITHOUT fix** (via `_Unfixed*` subclass overriding `tokenWaitingRefresh → token`) | New request during refresh gets unnecessary 401 (`totalErrorCount == 2`) |
| **WITH fix** (standard `Fresh`/`FreshLink`) | New request waits for refresh, avoids extra 401 (`totalErrorCount == 1`) |

### Test Results

- `fresh`: 33 tests ✅
- `fresh_dio`: 46 tests ✅
- `fresh_http`: 43 tests ✅
- `fresh_graphql`: 31 tests ✅

All existing tests pass, no lint warnings.

## Checklist

- [x] Fixes #141
- [x] No new dependencies
- [x] Covers fresh_dio, fresh_http, and fresh_graphql
- [x] Comprehensive test coverage with WITHOUT/WITH fix comparison
- [x] All existing tests pass
- [x] No lint warnings